### PR TITLE
Add docs sanity check

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,14 @@ python3 -m http.server 8000
 open http://localhost:8000
 ```
 
+## Sanity check
+
+```bash
+node ../scripts/check-docs.mjs
+```
+
+This verifies local docs links and media paths, plus the gallery count copy.
+
 ## Deploy (GitHub Pages)
 
 Fully self-contained — no build step. In the repo's **Settings → Pages**, set the source to **Deploy from a branch**, branch `main`, folder **`/docs`**.

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@
   <section class="gallery" aria-labelledby="gallery-title">
     <div class="gallery-head">
       <div>
-        <p class="gallery-eyebrow">five real projects · five real brags</p>
+        <p class="gallery-eyebrow">three real projects · three real brags</p>
         <h2 class="gallery-title" id="gallery-title">what twenty<br/>seconds of <em>brag</em><br/>looks like.</h2>
       </div>
       <p class="gallery-note">Tap play to watch with sound. The thumbnail opens the live site.</p>

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const docsDir = path.join(root, "docs");
+const indexPath = path.join(docsDir, "index.html");
+
+const numberWords = new Map([
+  ["zero", 0],
+  ["one", 1],
+  ["two", 2],
+  ["three", 3],
+  ["four", 4],
+  ["five", 5],
+  ["six", 6],
+  ["seven", 7],
+  ["eight", 8],
+  ["nine", 9],
+  ["ten", 10],
+]);
+
+const failures = [];
+const html = await readFile(indexPath, "utf8");
+
+function isLocalReference(value) {
+  return (
+    value &&
+    !value.startsWith("#") &&
+    !value.startsWith("//") &&
+    !/^[a-z][a-z0-9+.-]*:/i.test(value)
+  );
+}
+
+function localPathFor(value) {
+  const clean = value.split(/[?#]/, 1)[0];
+  return path.join(docsDir, clean);
+}
+
+function parseCount(value) {
+  const normalized = value.toLowerCase();
+  if (/^\d+$/.test(normalized)) return Number(normalized);
+  return numberWords.get(normalized);
+}
+
+for (const match of html.matchAll(/\b(?:src|href|poster)=["']([^"']+)["']/g)) {
+  const reference = match[1];
+  if (!isLocalReference(reference)) continue;
+
+  const target = localPathFor(reference);
+  if (!existsSync(target)) {
+    failures.push(`Missing local reference: ${reference}`);
+  }
+}
+
+const galleryVideos = [
+  ...html.matchAll(/<video\b[^>]*class=["'][^"']*\bbrag-video\b[^"']*["'][\s\S]*?<\/video>/g),
+];
+const galleryCount = galleryVideos.length;
+
+const galleryCopy = html.match(/>([^<>]*?)\s+real projects\s+.\s+([^<>]*?)\s+real brags</i);
+if (!galleryCopy) {
+  failures.push("Could not find gallery count copy.");
+} else {
+  const projectCount = parseCount(galleryCopy[1].trim());
+  const bragCount = parseCount(galleryCopy[2].trim());
+
+  if (projectCount !== galleryCount || bragCount !== galleryCount) {
+    failures.push(
+      `Gallery copy says ${galleryCopy[1].trim()} projects and ${galleryCopy[2].trim()} brags, but ${galleryCount} brag videos are listed.`,
+    );
+  }
+}
+
+for (const video of galleryVideos) {
+  const tag = video[0];
+  const src = tag.match(/\bsrc=["']([^"']+)["']/)?.[1];
+  const poster = tag.match(/\bposter=["']([^"']+)["']/)?.[1];
+
+  if (!src) failures.push("Gallery video is missing src.");
+  if (!poster) failures.push(`Gallery video ${src ?? "(unknown)"} is missing poster.`);
+
+  if (!src) continue;
+  const siteThumb = src.replace(/brag\.mp4(?:[?#].*)?$/, "site.jpg");
+  if (siteThumb === src || !existsSync(localPathFor(siteThumb))) {
+    failures.push(`Gallery video ${src} is missing matching site.jpg.`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Docs sanity check failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Docs sanity check passed: ${galleryCount} gallery videos and all local references exist.`);


### PR DESCRIPTION
Adds a small Node check for the static docs page. It verifies local `src`, `href`, and `poster` paths, makes sure each gallery video has its poster and `site.jpg`, and checks the gallery count copy matches the real videos. This also fixes the current copy from five projects to three.

Check run: `node scripts/check-docs.mjs`