### PR TITLE
Make /brag a pipeline with gates, still driven by one command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,20 @@ __pycache__/
 **/.venv/
 .uv-cache/
 
+# Node
+node_modules/
+**/node_modules/
+package-lock.json
+
+# Brag working state (per-product; regenerable, and captures hold whatever the
+# product printed)
+**/brag/captures/
+**/brag/renders/
+**/brag/compositions/
+**/brag/delivery/
+**/brag/tasks/
+**/brag/reviews/
+
 # Local tooling / machine config
 .playwright-mcp/
 .agents/
@@ -25,3 +39,11 @@ skills-lock.json
 # Codex packaging — excluded from the Claude-only initial release
 .codex-plugin/
 CODEX_PLUGIN_FOLLOWUPS.md
+
+# Per-agent instruction sidecars some tools generate in a checkout
+AGENTS.md
+GEMINI.md
+CLAUDE.md
+DECISIONS.md
+IMPLEMENTED.md
+TASKS.md

--- a/cli/brag.mjs
+++ b/cli/brag.mjs
@@ -34,6 +34,7 @@ const COMMANDS = {
   storyboard: { blurb: "build the scene graph", load: () => import("./commands/storyboard.mjs") },
   capture: { blurb: "record the real product surface", load: () => import("./commands/capture.mjs") },
   compose: { blurb: "compile the scene graph into a HyperFrames project", load: () => import("./commands/compose.mjs") },
+  frames: { blurb: "build frame packets and list the frames still to design", load: () => import("./commands/frames.mjs") },
   watch: { blurb: "turn a render into a reviewable bundle of frames and facts", load: () => import("./commands/watch.mjs") },
   review: { blurb: "run the four verification layers against a render", load: () => import("./commands/review.mjs") },
   revise: { blurb: "apply a scoped change without regenerating everything", load: () => import("./commands/revise.mjs") },

--- a/cli/brag.mjs
+++ b/cli/brag.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * brag — turn a project into a short, shareable launch video.
+ *
+ * Brag 1.0 is a direction and verification layer. It owns product truth,
+ * positioning, concept, scene graph, visual world, timing, review and
+ * variants; it compiles all of that into the artifacts HyperFrames already
+ * consumes, and HyperFrames owns everything from the DOM down.
+ *
+ * Every command exits non-zero on failure. That is the whole contract.
+ */
+
+import { parseArgs } from "node:util";
+import { readPackageVersion } from "./lib/state.mjs";
+import {
+  BragError,
+  EXIT,
+  configureOutput,
+  fail,
+  say,
+} from "./lib/util.mjs";
+
+/** Command registry. `load` is lazy so a broken command can't break `--help`. */
+const COMMANDS = {
+  init: { blurb: "create brag/ in the current project", load: () => import("./commands/init.mjs") },
+  status: { blurb: "show which pipeline stages are done and what is next", load: () => import("./commands/status.mjs") },
+  doctor: { blurb: "verify HyperFrames, ffmpeg and the skill pack are usable", load: () => import("./commands/doctor.mjs") },
+
+  inspect: { blurb: "classify the product surface and extract verified product truth", load: () => import("./commands/inspect.mjs") },
+  position: { blurb: "map audience, angle and every claim to a source", load: () => import("./commands/position.mjs") },
+  concepts: { blurb: "generate at least three distinct creative concepts", load: () => import("./commands/concepts.mjs") },
+  select: { blurb: "score the concepts and lock one", load: () => import("./commands/select.mjs") },
+  direct: { blurb: "choose the visual world and derive the design truth", load: () => import("./commands/direct.mjs") },
+  storyboard: { blurb: "build the scene graph", load: () => import("./commands/storyboard.mjs") },
+  capture: { blurb: "record the real product surface", load: () => import("./commands/capture.mjs") },
+  compose: { blurb: "compile the scene graph into a HyperFrames project", load: () => import("./commands/compose.mjs") },
+  watch: { blurb: "turn a render into a reviewable bundle of frames and facts", load: () => import("./commands/watch.mjs") },
+  review: { blurb: "run the four verification layers against a render", load: () => import("./commands/review.mjs") },
+  revise: { blurb: "apply a scoped change without regenerating everything", load: () => import("./commands/revise.mjs") },
+  variant: { blurb: "recompose the scene graph for another format", load: () => import("./commands/variant.mjs") },
+  deliver: { blurb: "render, pick a poster, write share copy and the manifest", load: () => import("./commands/deliver.mjs") },
+};
+
+/** Flags every command understands. */
+const GLOBAL_OPTIONS = {
+  project: { type: "string", short: "C" },
+  json: { type: "boolean", default: false },
+  quiet: { type: "boolean", short: "q", default: false },
+  help: { type: "boolean", short: "h", default: false },
+  version: { type: "boolean", short: "v", default: false },
+  // two-phase contract
+  emit: { type: "boolean", default: false },
+  accept: { type: "boolean", default: false },
+  // common modifiers
+  force: { type: "boolean", default: false },
+  name: { type: "string" },
+  variant: { type: "string" },
+  world: { type: "string" },
+  run: { type: "boolean", default: false },
+  narrative: { type: "boolean", default: false },
+  "accept-narrative": { type: "boolean", default: false },
+  duration: { type: "string" },
+  video: { type: "string" },
+  deep: { type: "boolean", default: false },
+  strict: { type: "boolean", default: false },
+};
+
+function printHelp() {
+  const width = Math.max(...Object.keys(COMMANDS).map((c) => c.length));
+  say(`brag ${readPackageVersion()} — turn a project into a launch video`);
+  say("");
+  say("Usage: brag <command> [options]");
+  say("");
+  say("Pipeline");
+  for (const [name, { blurb }] of Object.entries(COMMANDS)) {
+    say(`  ${name.padEnd(width)}  ${blurb}`);
+  }
+  say("");
+  say("Options");
+  say("  -C, --project <dir>  the project to brag about (default: cwd)");
+  say("      --emit           write a task spec for the agent to answer");
+  say("      --accept         validate the agent's answer and record it");
+  say("      --json           machine-readable output");
+  say("  -q, --quiet          suppress progress output");
+  say("  -h, --help           this text");
+  say("");
+  say("A stage is done when its artifact exists and validates. Run `brag status`");
+  say("at any point to see what is finished and what comes next.");
+}
+
+async function main(argv) {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      options: GLOBAL_OPTIONS,
+      allowPositionals: true,
+      strict: false,
+    });
+  } catch (e) {
+    throw new BragError(e.message, EXIT.USAGE);
+  }
+
+  const { values: flags, positionals } = parsed;
+  configureOutput({ json: flags.json, quiet: flags.quiet });
+
+  if (flags.version) {
+    say(readPackageVersion());
+    return EXIT.OK;
+  }
+
+  const [commandName, ...rest] = positionals;
+
+  if (!commandName || flags.help) {
+    printHelp();
+    return EXIT.OK;
+  }
+
+  const entry = COMMANDS[commandName];
+  if (!entry) {
+    const near = Object.keys(COMMANDS).filter((c) => c.startsWith(commandName[0]));
+    throw new BragError(
+      `unknown command "${commandName}"` +
+        (near.length ? `. Did you mean: ${near.join(", ")}?` : ". Run `brag --help`."),
+      EXIT.USAGE,
+    );
+  }
+
+  const mod = await entry.load();
+  if (typeof mod.run !== "function") {
+    throw new BragError(`command "${commandName}" is not implemented yet`, EXIT.USAGE);
+  }
+  const code = await mod.run({ flags, args: rest });
+  return typeof code === "number" ? code : EXIT.OK;
+}
+
+main(process.argv.slice(2))
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    if (err instanceof BragError) {
+      fail(err.message);
+      process.exit(err.code);
+    }
+    fail(err?.stack ?? String(err));
+    process.exit(EXIT.GATE);
+  });

--- a/cli/commands/capture.mjs
+++ b/cli/commands/capture.mjs
@@ -1,0 +1,182 @@
+/**
+ * brag capture — record the real product surface.
+ *
+ * Commands are never inferred and run. The agent proposes a capture plan, the
+ * user approves it, and only then does anything execute: this stage runs
+ * arbitrary commands from the product's own documentation, and guessing which
+ * ones are safe is not a decision a video tool should be making.
+ *
+ * `--plan` writes the proposal. `--run` executes an approved plan.
+ */
+
+import path from "node:path";
+import { captureTerminal, sessionText } from "../lib/capture/terminal.mjs";
+import { resolveProject } from "../lib/state.mjs";
+import { readPackageVersion } from "../lib/state.mjs";
+import { EXIT, exists, gateError, report, say, writeJson } from "../lib/util.mjs";
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  project.load();
+  if (flags.run) return execute(project, flags);
+  return plan(project);
+}
+
+/* ------------------------------------------------------------------ plan */
+
+function plan(project) {
+  const model = project.read("product_model.json");
+  const signals = project.read("signals.json", { optional: true });
+
+  const surfaces = model.visual_surfaces.filter((s) => s.capture === "terminal_tape");
+  if (!surfaces.length) {
+    throw gateError(
+      `no visual surface in this product model asks for a terminal tape. ` +
+        `Surfaces: ${model.visual_surfaces.map((s) => `${s.id} (${s.capture ?? "none"})`).join(", ")}`,
+    );
+  }
+
+  const suggested = (signals?.candidate_commands ?? [])
+    .map((c) => c.command)
+    .filter((c) => !/^(rm|del|sudo|curl|wget|git push|npm publish)\b/.test(c))
+    .slice(0, 8);
+
+  const plan = {
+    schema: "brag.capture_plan/1",
+    approved: false,
+    geometry: { cols: 100, rows: 30 },
+    invocations: suggested.map((command, i) => ({
+      id: `cmd_${i + 1}`,
+      display_command: command,
+      argv: command.split(/\s+/),
+      cwd: ".",
+      expect_exit: 0,
+      surface: surfaces[0].id,
+      include: false,
+    })),
+    note:
+      "Nothing runs until `approved` is true. Set `include: true` on the invocations you " +
+      "want captured, fix any argv the naive split got wrong, and check that none of them " +
+      "change state you care about — these run for real.",
+  };
+
+  const file = project.path("capture_plan.json");
+  if (exists(file)) {
+    say("A capture plan already exists; leaving it alone. Delete it to regenerate.");
+  } else {
+    writeJson(file, plan);
+  }
+
+  report(
+    { ok: true, mode: "plan", path: file, suggested: suggested.length },
+    [
+      `Proposed ${suggested.length} command(s) from the project's own documentation.`,
+      `  ${path.relative(project.targetRoot, file)}`,
+      "",
+      "These will run for real. Review them, set `include: true` on the ones you want,",
+      "set `approved: true`, then:",
+      "  brag capture --run",
+    ],
+  );
+  return EXIT.OK;
+}
+
+/* ------------------------------------------------------------------ run */
+
+async function execute(project, flags) {
+  const plan = project.read("capture_plan.json");
+
+  if (!plan.approved && !flags.force) {
+    throw gateError(
+      "the capture plan is not approved. These commands run for real against your machine — " +
+        "read them, then set `approved: true` in capture_plan.json.",
+    );
+  }
+
+  const chosen = plan.invocations.filter((i) => i.include);
+  if (!chosen.length) {
+    throw gateError("no invocation in the plan has `include: true`, so there is nothing to capture.");
+  }
+
+  const sessions = [];
+  for (const invocation of chosen) {
+    say(`Running \`${invocation.display_command}\`…`);
+    const session = await captureTerminal({
+      id: invocation.id,
+      argv: invocation.argv,
+      displayCommand: invocation.display_command,
+      cwd: path.resolve(project.targetRoot, invocation.cwd ?? "."),
+      geometry: plan.geometry,
+      expectExit: invocation.expect_exit ?? 0,
+      toolVersion: readPackageVersion(),
+    });
+    writeJson(project.path("captures", "terminal", `${invocation.id}.session.json`), session);
+    sessions.push({ invocation, session });
+  }
+
+  /* The manifest is what the fidelity check resolves rendered strings against,
+     so it carries the text each session actually printed. */
+  const manifest = {
+    schema: "brag.capture_manifest/1",
+    captured_at: new Date().toISOString(),
+    sessions: sessions.map(({ invocation, session }) => ({
+      id: invocation.id,
+      surface: invocation.surface,
+      kind: "terminal_tape",
+      path: `captures/terminal/${invocation.id}.session.json`,
+      display_command: session.invocation.display_command,
+      exit_code: session.invocation.exit_code,
+      states: session.states.length,
+      redactions: session.provenance.redactions,
+      pty: session.environment.pty,
+      lines: sessionText(session),
+    })),
+  };
+  writeJson(project.path("captures", "capture_manifest.json"), manifest);
+
+  const unresolved = checkVerbatim(project, manifest);
+
+  report(
+    {
+      ok: true,
+      mode: "run",
+      sessions: manifest.sessions.map((s) => ({ id: s.id, states: s.states })),
+      unresolved,
+    },
+    [
+      `Captured ${sessions.length} session(s).`,
+      ...manifest.sessions.map(
+        (s) =>
+          `  ${s.id.padEnd(10)} ${s.states} settled state(s)` +
+          (s.redactions.length ? `  redacted: ${s.redactions.map((r) => `${r.count} ${r.kind}`).join(", ")}` : ""),
+      ),
+      !sessions.some(({ session }) => session.environment.pty)
+        ? "  note: captured without a pty, so spinners a tool only draws to a tty may be missing"
+        : "",
+      unresolved.length
+        ? `  ${unresolved.length} verbatim string(s) still have no capture backing them: ${unresolved.join(", ")}`
+        : "  every verbatim string in the product model appears in a capture",
+      "",
+      "Next: brag compose",
+    ].filter(Boolean),
+  );
+  return EXIT.OK;
+}
+
+/**
+ * Which verbatim strings the captures actually back up. Reported rather than
+ * enforced: some copy legitimately comes from a README rather than a run, and
+ * the fidelity layer is where the full accounting belongs.
+ */
+function checkVerbatim(project, manifest) {
+  const model = project.read("product_model.json");
+  const haystack = manifest.sessions
+    .flatMap((s) => s.lines)
+    .join("\n")
+    .replace(/\s+/g, " ");
+
+  return (model.verbatim_copy ?? [])
+    .filter((v) => v.kind === "output" || v.kind === "command")
+    .filter((v) => !haystack.includes(v.text.replace(/\s+/g, " ").trim()))
+    .map((v) => v.id);
+}

--- a/cli/commands/compose.mjs
+++ b/cli/commands/compose.mjs
@@ -1,0 +1,318 @@
+/**
+ * brag compose — compile the scene graph into a HyperFrames project.
+ *
+ * This is the boundary made mechanical. Brag decides what the video is about,
+ * what must be readable, what must be proven, and how each cut travels; from
+ * here down HyperFrames owns the DOM, the timeline and the render.
+ *
+ * The compile is deterministic: same graph in, byte-identical project out.
+ * That property is what lets a later phase claim a scoped revision touched
+ * only the scenes it named.
+ */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { buildFrameStub, buildIndexHtml, projectFiles } from "../lib/compile/composition.mjs";
+import {
+  buildBrief,
+  buildFrameMd,
+  buildLedger,
+  buildMotionJson,
+  buildStoryboard,
+  frameFile,
+  totalDuration,
+  withStarts,
+} from "../lib/compile/targets.mjs";
+import {
+  HYPERFRAMES_PIN,
+  blueprintIds,
+  hyperframes,
+  ruleIds,
+  seamStampScript,
+  transitionNames,
+  verifySeams,
+} from "../lib/hyperframes.mjs";
+import { assertValid } from "../lib/schema.mjs";
+import { assertSameness, fingerprint } from "../lib/score/fingerprint.mjs";
+import { getWorld, worldsFor } from "../lib/worlds.mjs";
+import { applyTiming, solveTiming } from "../lib/solve/timing.mjs";
+import { Memory, REPO_ROOT, resolveProject } from "../lib/state.mjs";
+import {
+  EXIT,
+  ensureDir,
+  gateError,
+  report,
+  say,
+  stableStringify,
+  warn,
+  writeFileAtomic,
+  writeJson,
+} from "../lib/util.mjs";
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  const info = project.load();
+
+  const model = project.read("product_model.json");
+  const positioning = project.read("positioning.json");
+  let graph = assertValid(REPO_ROOT, "scene_graph", project.read("scene_graph.json"), {
+    source: "scene_graph.json",
+  });
+  const concept = project.read("selected_concept.json", { optional: true });
+
+  await validateGraph({ graph, model, concept });
+
+  /* Solve timing before anything is written, so the composition, the motion
+     sidecar and the ledger all read one answer rather than three. */
+  const plan = solveTiming(graph, {
+    targetDuration: flags.duration ? Number(flags.duration) : null,
+    strongCues: graph.audio?.strong_cue_locks ?? [],
+  });
+  if (!plan.ok) {
+    throw gateError(
+      "the edit does not fit its own copy:\n" +
+        plan.violations.map((v) => `  - ${v.message}`).join("\n") +
+        "\n\nThe reading floor is not negotiable; change the copy or the ceiling.",
+    );
+  }
+  for (const r of plan.relaxations) warn(r.message);
+  project.write("timing_plan.json", plan);
+  graph = applyTiming(graph, plan);
+
+  const world = getWorld(
+    flags.world ?? graph.visual_world ?? worldsFor(model.surface_type)[0].id,
+  );
+
+  /* Is this the same video again? Measured before anything is rendered, so a
+     repeat costs seconds rather than a full render. */
+  const fp = fingerprint({ graph, world });
+  const sameness = assertSameness(fp, new Memory().recentFingerprints(10));
+  for (const a of sameness.advisories) warn(`${a.message} — ${a.fix}`);
+  project.write("fingerprint.json", fp);
+
+  const variant =
+    flags.variant ?? graph.format.name ?? `${graph.format.width}x${graph.format.height}`;
+  const outDir = project.path("compositions", variant);
+  ensureDir(outDir);
+
+  /* ---------------------------------------------------------- write targets */
+
+  const written = [];
+  const put = (rel, contents) => {
+    writeFileAtomic(path.join(outDir, rel), contents);
+    written.push(rel.split(path.sep).join("/"));
+  };
+
+  for (const [name, contents] of Object.entries(
+    projectFiles({ name: `${info.name}-${variant}`, graph, pin: HYPERFRAMES_PIN }),
+  )) {
+    put(name, contents);
+  }
+
+  put("BRIEF.md", buildBrief({ model, positioning, graph, concept }));
+  put("STORYBOARD.md", buildStoryboard({ graph, positioning, model }));
+  put("frame.md", buildFrameMd({ model, graph, world }));
+  /* Captured sessions, keyed by id, so a scene can show the real thing the
+     tool printed rather than a paragraph describing it. */
+  const captureManifest = project.read("captures/capture_manifest.json", { optional: true });
+  const captures = Object.fromEntries(
+    (captureManifest?.sessions ?? [])
+      .map((entry) => [entry.id, project.read(entry.path, { optional: true })])
+      .filter(([, session]) => session),
+  );
+
+  put("index.html", buildIndexHtml({ model, graph, world, captures }));
+  put("ledger.json", stableStringify(buildLedger({ graph })));
+  put("index.motion.json", stableStringify(buildMotionJson({ graph })));
+  /* The solved graph travels with the composition it produced, so delivery
+     reads the graph this variant was actually built from rather than
+     whatever happens to be current in the project. */
+  put("scene_graph.json", stableStringify(graph));
+
+  const scenes = withStarts(graph);
+  scenes.forEach((scene, i) => {
+    put(path.join("compositions", "frames", frameFile(i, scene)), buildFrameStub({ scene, model, graph }));
+  });
+
+  const existing = project.read("compositions/index.json", { optional: true }) ?? { variants: {} };
+  existing.variants[variant] = {
+    path: `compositions/${variant}`,
+    compiled_at: new Date().toISOString(),
+    format: graph.format,
+    duration: totalDuration(graph),
+    scenes: scenes.length,
+    seams: (graph.seams ?? []).length,
+  };
+  writeJson(project.path("compositions", "index.json"), existing);
+
+  /* ---------------------------------------------------------- stamp + gates */
+
+  if ((graph.seams ?? []).length) {
+    const stamp = spawnSync(
+      process.execPath,
+      [seamStampScript(), "--ledger", "ledger.json", "--write", "index.html"],
+      { cwd: outDir, encoding: "utf8", timeout: 120_000 },
+    );
+    if (stamp.status !== 0) {
+      throw gateError(
+        `seam-stamp could not write the seam block:\n${(stamp.stderr || stamp.stdout || "").trim()}`,
+      );
+    }
+  }
+
+  if (flags["skip-gates"]) {
+    return finish({ project, variant, outDir, written, graph, gates: null });
+  }
+
+  say(`Compiled ${written.length} files into ${path.relative(project.targetRoot, outDir)}. Checking…`);
+
+  const check = hyperframes(["check"], { cwd: outDir });
+  const seams = (graph.seams ?? []).length
+    ? verifySeams({ cwd: outDir })
+    : { status: 0, stdout: "no seams to verify" };
+
+  const gates = {
+    check: { ok: check.status === 0, output: tail(check.stdout || check.stderr) },
+    seam_gate: { ok: seams.status === 0, output: tail(seams.stdout || seams.stderr) },
+  };
+
+  if (!gates.check.ok || !gates.seam_gate.ok) {
+    throw gateError(
+      [
+        "the compiled project does not pass its gates:",
+        gates.check.ok ? null : `\n[hyperframes check]\n${gates.check.output}`,
+        gates.seam_gate.ok ? null : `\n[seam gate]\n${gates.seam_gate.output}`,
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+
+  return finish({ project, variant, outDir, written, graph, gates });
+}
+
+/* ------------------------------------------------------------------ validation */
+
+/**
+ * Everything checkable before a browser is involved. Cited motion ids are
+ * validated against the installed pack, so a scene can never reference a rule
+ * that does not exist — the failure the runtime index read exists to prevent.
+ */
+async function validateGraph({ graph, model, concept }) {
+  const problems = [];
+
+  /* A locked concept is a constraint, not a note. If a forbidden motif shows
+     up in what the scenes say they are doing, the implementation has drifted
+     back into the generic version of itself — which is the exact failure the
+     lock exists to catch. */
+  if (concept?.forbidden_motifs?.length) {
+    const normalise = (t) => String(t).toLowerCase().replace(/[^a-z0-9 ]+/g, " ").replace(/\s+/g, " ").trim();
+    const surface = graph.scenes
+      .map((sc) => [sc.purpose, sc.title, sc.motif, sc.motion?.intent].filter(Boolean).join(" "))
+      .join(" • ");
+    const haystack = normalise(surface);
+    for (const motif of concept.forbidden_motifs) {
+      const needle = normalise(motif);
+      if (needle && haystack.includes(needle)) {
+        problems.push(
+          `a scene describes "${motif}", which the locked concept "${concept.id}" forbids`,
+        );
+      }
+    }
+  }
+
+  const sceneIds = new Set(graph.scenes.map((s) => s.id));
+  const objectIds = new Set((graph.objects ?? []).map((o) => o.id));
+  const proofIds = new Set(model.proof.map((p) => p.id));
+
+  if (sceneIds.size !== graph.scenes.length) problems.push("two scenes share an id");
+
+  for (const scene of graph.scenes) {
+    for (const ref of scene.required_proof ?? []) {
+      if (!proofIds.has(ref)) {
+        problems.push(`scene "${scene.id}" requires proof "${ref}", which is not in the product model`);
+      }
+    }
+    for (const o of scene.objects ?? []) {
+      if (!objectIds.has(o.id)) {
+        problems.push(`scene "${scene.id}" uses object "${o.id}", which is not declared`);
+      }
+    }
+    for (const link of ["continuity_from", "continuity_to"]) {
+      const target = scene[link];
+      if (target && !sceneIds.has(target)) {
+        problems.push(`scene "${scene.id}".${link} points at "${target}", which is not a scene`);
+      }
+    }
+  }
+
+  for (const seam of graph.seams ?? []) {
+    if (!sceneIds.has(seam.from)) problems.push(`seam from "${seam.from}" — no such scene`);
+    if (!sceneIds.has(seam.to)) problems.push(`seam to "${seam.to}" — no such scene`);
+  }
+
+  const cited = graph.scenes.flatMap((s) => s.motion?.rules ?? []);
+  const blueprints = graph.scenes.map((s) => s.motion?.blueprint).filter(Boolean);
+  if (cited.length || blueprints.length) {
+    const rules = await ruleIds();
+    for (const id of cited) {
+      if (!rules.has(id)) {
+        problems.push(`scene motion cites rule "${id}", which is not in the installed pack`);
+      }
+    }
+    const known = blueprintIds();
+    for (const id of blueprints) {
+      if (!known.has(id)) {
+        problems.push(`scene motion cites blueprint "${id}", which is not in the installed pack`);
+      }
+    }
+  }
+
+  const registry = transitionNames();
+  for (const seam of graph.seams ?? []) {
+    if (!seam.technique) continue;
+    const base = seam.technique.split(/\s+/)[0];
+    if (!registry.has(seam.technique) && !registry.has(base) && !/^(cut|morph|match-cut)/i.test(seam.technique)) {
+      warn(
+        `seam ${seam.from}→${seam.to} names "${seam.technique}", which is not in the transition registry ` +
+          `(${[...registry].join(", ")}).`,
+      );
+    }
+  }
+
+  if (problems.length) {
+    throw gateError("the scene graph does not resolve:\n" + problems.map((p) => `  - ${p}`).join("\n"));
+  }
+}
+
+/* ------------------------------------------------------------------ output */
+
+function finish({ project, variant, outDir, written, graph, gates }) {
+  report(
+    {
+      ok: true,
+      variant,
+      path: outDir,
+      files: written.length,
+      duration: totalDuration(graph),
+      scenes: graph.scenes.length,
+      gates,
+    },
+    [
+      `Compiled "${variant}" — ${graph.scenes.length} scenes, ${totalDuration(graph)}s, ${written.length} files.`,
+      `  ${path.relative(project.targetRoot, outDir)}`,
+      gates ? "  hyperframes check: pass" : "  gates skipped",
+      gates ? "  seam gate: pass" : "",
+      "",
+      "Next: brag deliver",
+    ].filter(Boolean),
+  );
+  return EXIT.OK;
+}
+
+const tail = (s, lines = 30) =>
+  String(s || "")
+    .trimEnd()
+    .split("\n")
+    .slice(-lines)
+    .join("\n");

--- a/cli/commands/compose.mjs
+++ b/cli/commands/compose.mjs
@@ -83,15 +83,21 @@ export async function run({ flags }) {
     flags.world ?? graph.visual_world ?? worldsFor(model.surface_type)[0].id,
   );
 
+  const variant =
+    flags.variant ?? graph.format.name ?? `${graph.format.width}x${graph.format.height}`;
+
   /* Is this the same video again? Measured before anything is rendered, so a
-     repeat costs seconds rather than a full render. */
+     repeat costs seconds rather than a full render. This variant's own earlier
+     deliveries are excluded: recompiling a film after fixing something in it
+     is meant to produce the same film. */
   const fp = fingerprint({ graph, world });
-  const sameness = assertSameness(fp, new Memory().recentFingerprints(10));
+  const sameness = assertSameness(
+    fp,
+    new Memory().recentFingerprints(10, { exclude: { project: info.name, variant } }),
+  );
   for (const a of sameness.advisories) warn(`${a.message} — ${a.fix}`);
   project.write("fingerprint.json", fp);
 
-  const variant =
-    flags.variant ?? graph.format.name ?? `${graph.format.width}x${graph.format.height}`;
   const outDir = project.path("compositions", variant);
   ensureDir(outDir);
 

--- a/cli/commands/compose.mjs
+++ b/cli/commands/compose.mjs
@@ -11,6 +11,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { buildFrameStub, buildIndexHtml, projectFiles } from "../lib/compile/composition.mjs";
 import {
@@ -127,7 +128,31 @@ export async function run({ flags }) {
       .filter(([, session]) => session),
   );
 
-  put("index.html", buildIndexHtml({ model, graph, world, captures }));
+  /* Frames a worker has already designed. A stub is an outline waiting to be
+     built, so it does not count — mounting one would put the scaffold on
+     screen with extra steps. */
+  const scenesForFrames = withStarts(graph);
+  const designedFrames = new Map();
+  scenesForFrames.forEach((scene, i) => {
+    const rel = path.posix.join("compositions", "frames", frameFile(i, scene));
+    const abs = path.join(outDir, rel.split("/").join(path.sep));
+    if (!fs.existsSync(abs)) return;
+    const contents = fs.readFileSync(abs, "utf8");
+    if (/^<!-- outline frame:/.test(contents.trimStart())) return;
+    /* The host's id has to match the one inside the file it mounts, and the
+       file is the authority on what that is — deriving it from the filename
+       would break the moment a worker names its root anything else. */
+    const declared = contents.match(/data-composition-id="([^"]+)"/);
+    if (!declared) {
+      throw gateError(
+        `${rel} has no data-composition-id, so nothing can mount it. ` +
+          "A frame's root must declare the id the storyboard knows it by.",
+      );
+    }
+    designedFrames.set(scene.id, { src: rel, compositionId: declared[1] });
+  });
+
+  put("index.html", buildIndexHtml({ model, graph, world, captures, designedFrames }));
   put("ledger.json", stableStringify(buildLedger({ graph })));
   put("index.motion.json", stableStringify(buildMotionJson({ graph })));
   /* The solved graph travels with the composition it produced, so delivery
@@ -135,10 +160,26 @@ export async function run({ flags }) {
      whatever happens to be current in the project. */
   put("scene_graph.json", stableStringify(graph));
 
-  const scenes = withStarts(graph);
+  const scenes = scenesForFrames;
+  const liveFrames = new Set(scenes.map((scene, i) => frameFile(i, scene)));
   scenes.forEach((scene, i) => {
+    /* Never overwrite a designed frame with its own outline. */
+    if (designedFrames.has(scene.id)) return;
     put(path.join("compositions", "frames", frameFile(i, scene)), buildFrameStub({ scene, model, graph }));
   });
+
+  /* Frames whose scene no longer exists. Renaming a scene or cutting one
+     leaves its file behind, and `check` reads every file in the project — so
+     a deleted scene keeps failing the gate from beyond the grave, with an
+     error naming a frame the storyboard has not mentioned for three edits. */
+  const framesDir = path.join(outDir, "compositions", "frames");
+  if (fs.existsSync(framesDir)) {
+    for (const name of fs.readdirSync(framesDir)) {
+      if (!name.endsWith(".html") || liveFrames.has(name)) continue;
+      fs.rmSync(path.join(framesDir, name));
+      warn(`removed compositions/frames/${name}: no scene in the graph builds it`);
+    }
+  }
 
   const existing = project.read("compositions/index.json", { optional: true }) ?? { variants: {} };
   existing.variants[variant] = {

--- a/cli/commands/concepts.mjs
+++ b/cli/commands/concepts.mjs
@@ -1,0 +1,122 @@
+/**
+ * brag concepts — at least three genuinely different ways to make this video.
+ *
+ * The step exists because going straight from inspection to one storyboard
+ * produces the same film every time. On accept, distinctness is measured
+ * rather than trusted: three descriptions of the same idea are rejected before
+ * anything gets scored.
+ */
+
+import path from "node:path";
+import { checkDistinct, DISTINCTNESS_CEILING } from "../lib/score/concept.mjs";
+import { Memory, resolveProject } from "../lib/state.mjs";
+import { acceptTaskAnswer, emitTaskSpec } from "../lib/taskspec.mjs";
+import { loadWorlds } from "../lib/worlds.mjs";
+import { EXIT, gateError, report } from "../lib/util.mjs";
+
+const TASK = "concepts";
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  project.load();
+  return flags.accept ? accept(project) : emit(project);
+}
+
+function emit(project) {
+  const model = project.read("product_model.json");
+  const positioning = project.read("positioning.json");
+  const history = new Memory().recentFingerprints(10);
+
+  const { specPath } = emitTaskSpec({
+    project,
+    name: TASK,
+    title: "Propose at least three ways to make this video",
+    objective:
+      "Find genuinely different films that all tell the truth about this product. They should " +
+      "be hard to choose between. If one is obviously best, the other two were not tried.",
+    instructions: [
+      "Each concept needs a central metaphor — one idea every scene serves. \"Context is a baton passed between agents\" is a metaphor; \"it is fast and reliable\" is a claim.",
+      "Give each a visual rule strong enough that breaking it would be obvious, and an emotional arc: where the viewer starts and ends.",
+      "Fill `forbidden_motifs` with what this concept must never drift into — usually the generic version of itself.",
+      "Answer `why_this_product` honestly. If the concept would work for any product in the category, it is a template, not a concept.",
+      "Vary the *kind* of film, not just the words. Three concepts that are all narrated typography are one concept.",
+      "Suggest a visual world where one obviously fits, from the list below.",
+      "Name each concept's `risk`: the most likely way it fails in execution.",
+    ],
+    schemaName: "concept",
+    context: {
+      product: {
+        name: model.name,
+        surface_type: model.surface_type,
+        problem: model.problem,
+        mechanism: model.mechanism,
+        visual_surfaces: model.visual_surfaces,
+      },
+      angle: positioning.angle,
+      audience: positioning.audience,
+      claims: positioning.claims,
+      proofs: model.proof.map((p) => ({ id: p.id, claim: p.claim, strength: p.strength })),
+      forbidden_claims: model.forbidden_claims,
+      available_worlds: loadWorlds().map((w) => ({
+        id: w.id,
+        summary: w.summary,
+        camera: w.camera_model,
+        suits: w.suits_surfaces,
+      })),
+      recent_videos: history.map((f) => ({ world: f.world, motifs: f.object_motifs })),
+    },
+    rejects: [
+      `Two concepts whose idea words overlap by ${DISTINCTNESS_CEILING * 100}% or more — that is one concept in two costumes.`,
+      "A concept that reuses a world and motif set from `recent_videos`.",
+      "A `central_metaphor` that is really a feature claim.",
+    ],
+  });
+
+  report(
+    { ok: true, mode: "emit", spec: specPath, answer: project.answerPath(TASK) },
+    [
+      `${loadWorlds().length} visual worlds available; ${history.length} recent video(s) to differ from.`,
+      "",
+      `Read ${path.relative(project.targetRoot, specPath)}, write the JSON, then:`,
+      "  brag concepts --accept",
+    ],
+  );
+  return EXIT.OK;
+}
+
+function accept(project) {
+  const answer = acceptTaskAnswer({ project, name: TASK, schemaName: "concept" });
+  const concepts = answer.concepts;
+
+  const ids = new Set(concepts.map((c) => c.id));
+  if (ids.size !== concepts.length) throw gateError("two concepts share an id");
+
+  const distinct = checkDistinct(concepts);
+  if (!distinct.ok) {
+    throw gateError(
+      "these are not different concepts:\n" +
+        distinct.pairs
+          .map(
+            (p) =>
+              `  - "${p.a}" and "${p.b}" share ${(p.overlap * 100).toFixed(0)}% of their idea words ` +
+              `(ceiling ${DISTINCTNESS_CEILING * 100}%)`,
+          )
+          .join("\n") +
+        "\n\nChange the kind of film, not the wording.",
+    );
+  }
+
+  project.write("concepts.json", answer);
+  for (const concept of concepts) project.write(path.join("concepts", `${concept.id}.json`), concept);
+
+  report(
+    { ok: true, mode: "accept", concepts: concepts.map((c) => c.id) },
+    [
+      `Recorded ${concepts.length} distinct concepts:`,
+      ...concepts.map((c) => `  ${c.id.padEnd(20)} ${c.central_metaphor}`),
+      "",
+      "Next: brag select --emit",
+    ],
+  );
+  return EXIT.OK;
+}

--- a/cli/commands/deliver.mjs
+++ b/cli/commands/deliver.mjs
@@ -1,0 +1,218 @@
+/**
+ * brag deliver — render, pick a poster, bake it as frame zero, write the manifest.
+ *
+ * The poster is not an afterthought. A bare .mp4 has no poster attribute, and
+ * every platform that regenerates thumbnails server-side grabs frame 0 — so an
+ * unhandled render advertises itself with whatever happens to be at t=0, which
+ * on a well-made video is usually an empty background mid-fade. Brag picks the
+ * strongest settled moment it can name and makes frame 0 *be* that frame.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { withStarts, readingFloor } from "../lib/compile/targets.mjs";
+import { hyperframes } from "../lib/hyperframes.mjs";
+import { resolveProject, Memory } from "../lib/state.mjs";
+import {
+  EXIT,
+  ensureDir,
+  envError,
+  gateError,
+  report,
+  say,
+  writeFileAtomic,
+  writeJson,
+} from "../lib/util.mjs";
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  const info = project.load();
+  const model = project.read("product_model.json");
+  const positioning = project.read("positioning.json");
+
+  const index = project.read("compositions/index.json");
+  /* Default to the most recently compiled variant. Taking the first key
+     silently delivered an older composition while using the current graph to
+     pick its poster — two different videos spliced into one claim. */
+  const variant =
+    flags.variant ??
+    Object.entries(index.variants)
+      .sort((a, b) => String(b[1].compiled_at ?? "").localeCompare(String(a[1].compiled_at ?? "")))
+      .map(([name]) => name)[0];
+  const entry = index.variants[variant];
+  if (!entry) {
+    throw gateError(
+      `no compiled variant named "${variant}". Have: ${Object.keys(index.variants).join(", ") || "(none)"}`,
+    );
+  }
+
+  const compDir = project.path("compositions", variant);
+  /* The graph this variant was compiled from, not the project's current one. */
+  const graph =
+    project.read(`compositions/${variant}/scene_graph.json`, { optional: true }) ??
+    project.read("scene_graph.json");
+  const renderDir = ensureDir(project.path("renders"));
+  const deliveryDir = ensureDir(project.path("delivery"));
+  const mp4 = path.join(renderDir, `${variant}.mp4`);
+  const jpg = path.join(deliveryDir, `${variant}.jpg`);
+  const finalMp4 = path.join(deliveryDir, `${variant}.mp4`);
+
+  /* ---------------------------------------------------------------- render */
+
+  const quality = flags.draft ? "draft" : "high";
+  say(`Rendering ${variant} at ${quality} quality…`);
+  const render = hyperframes(["render", "--quality", quality, "--output", mp4], { cwd: compDir });
+  if (render.status !== 0 || !fs.existsSync(mp4)) {
+    throw gateError(`render failed:\n${tail(render.stderr || render.stdout)}`);
+  }
+
+  const probed = probe(mp4);
+  if (!probed.duration) throw gateError(`rendered file has no readable duration: ${mp4}`);
+
+  /* ---------------------------------------------------------------- poster */
+
+  const poster = choosePoster(graph);
+  say(`Poster: ${poster.why} at ${poster.at}s`);
+
+  run_(["-v", "error", "-ss", String(poster.at), "-i", mp4, "-frames:v", "1", "-q:v", "2", jpg, "-y"]);
+  if (!fs.existsSync(jpg)) throw gateError("ffmpeg produced no poster frame");
+
+  /* Replace only frame 0's pixels; every other frame, the duration and the
+     audio pass through untouched. At 30fps the poster shows for 1/30s. */
+  const baked = `${finalMp4}.tmp.mp4`;
+  run_([
+    "-y", "-v", "error",
+    "-i", mp4,
+    "-i", jpg,
+    "-filter_complex", "[0:v][1:v]overlay=0:0:enable='eq(n,0)'[v]",
+    "-map", "[v]", "-map", "0:a?",
+    "-c:v", "libx264", "-crf", "18", "-preset", "slow", "-pix_fmt", "yuv420p",
+    "-c:a", "copy", "-movflags", "+faststart",
+    baked,
+  ]);
+  fs.renameSync(baked, finalMp4);
+
+  const finalProbe = probe(finalMp4);
+  if (Math.abs(finalProbe.duration - probed.duration) > 0.1) {
+    throw gateError(
+      `baking the poster changed the duration (${probed.duration}s → ${finalProbe.duration}s); refusing to deliver`,
+    );
+  }
+
+  /* ---------------------------------------------------------------- copy + manifest */
+
+  const shareCopy = buildShareCopy({ model, positioning });
+  writeFileAtomic(path.join(deliveryDir, `${variant}.share-copy.txt`), shareCopy);
+
+  const manifest = {
+    schema: "brag.delivery/1",
+    project: info.name,
+    variant,
+    format: entry.format,
+    duration: finalProbe.duration,
+    has_audio: finalProbe.hasAudio,
+    bytes: fs.statSync(finalMp4).size,
+    video: path.relative(project.dir, finalMp4).split(path.sep).join("/"),
+    poster: path.relative(project.dir, jpg).split(path.sep).join("/"),
+    poster_at: poster.at,
+    poster_reason: poster.why,
+    share_copy: `delivery/${variant}.share-copy.txt`,
+    scenes: graph.scenes.map((s) => ({ id: s.id, purpose: s.purpose, proof: s.required_proof ?? [] })),
+    claims: positioning.claims,
+    delivered_at: new Date().toISOString(),
+  };
+  writeJson(path.join(deliveryDir, "manifest.json"), manifest);
+
+  new Memory().appendVideo({
+    id: `${info.name}:${variant}:${manifest.delivered_at}`,
+    project: info.name,
+    variant,
+    delivered_at: manifest.delivered_at,
+    fingerprint: project.read("fingerprint.json", { optional: true }),
+  });
+
+  report(
+    { ok: true, ...manifest },
+    [
+      `Delivered ${variant}.`,
+      `  ${path.relative(project.targetRoot, finalMp4)}  ${(manifest.bytes / 1e6).toFixed(1)} MB · ${manifest.duration}s${manifest.has_audio ? " · audio" : " · silent"}`,
+      `  poster baked as frame 0 from ${poster.at}s (${poster.why})`,
+      `  ${path.relative(project.targetRoot, path.join(deliveryDir, `${variant}.share-copy.txt`))}`,
+    ],
+  );
+  return EXIT.OK;
+}
+
+/* ------------------------------------------------------------------ poster */
+
+/**
+ * Pick the strongest *settled* moment: a frame where the copy has finished
+ * animating and has not begun to leave. Preference goes to the scene carrying
+ * the most proof, because that is the frame worth being seen on its own.
+ */
+function choosePoster(graph) {
+  const scenes = withStarts(graph);
+  const scored = scenes
+    .map((scene) => {
+      const reading = scene.reading ?? [];
+      const floor = Math.max(
+        0.8,
+        ...reading.map((r) => r.min_reading_s ?? readingFloor(r.text)),
+      );
+      const settleAt = Math.max(scene.start + 0.6, scene.start + scene.duration - floor + 0.15);
+      const safe = Math.min(settleAt, scene.start + scene.duration - 0.25);
+      return {
+        at: Number(safe.toFixed(2)),
+        score:
+          (scene.required_proof?.length ?? 0) * 3 +
+          reading.length +
+          (scene.role === "Brand_Outro" ? 2 : 0),
+        why: `${scene.id} settled${scene.required_proof?.length ? ` (shows ${scene.required_proof.join(", ")})` : ""}`,
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+  return scored[0] ?? { at: 0.5, why: "first settled frame" };
+}
+
+/* ------------------------------------------------------------------ share copy */
+
+function buildShareCopy({ model, positioning }) {
+  const lines = [positioning.angle];
+  const strongest = positioning.claims.find((c) => c.verbatim) ?? positioning.claims[0];
+  const proof = model.proof.find((p) => p.id === strongest?.proof_ref);
+  if (proof && proof.strength === "measured") lines.push(proof.claim + ".");
+  else if (model.one_line) lines.push(model.one_line);
+  lines.push(positioning.action);
+  return lines.filter(Boolean).join("\n") + "\n";
+}
+
+/* ------------------------------------------------------------------ ffmpeg */
+
+function run_(args) {
+  const res = spawnSync("ffmpeg", args, { encoding: "utf8", timeout: 600_000 });
+  if (res.error?.code === "ENOENT") throw envError("ffmpeg is not on PATH");
+  if (res.status !== 0) throw gateError(`ffmpeg failed:\n${tail(res.stderr)}`);
+  return res;
+}
+
+function probe(file) {
+  const res = spawnSync(
+    "ffprobe",
+    ["-v", "error", "-show_entries", "format=duration", "-show_entries", "stream=codec_type", "-of", "json", file],
+    { encoding: "utf8", timeout: 60_000 },
+  );
+  if (res.error?.code === "ENOENT") throw envError("ffprobe is not on PATH");
+  try {
+    const parsed = JSON.parse(res.stdout);
+    return {
+      duration: Number(Number(parsed.format?.duration ?? 0).toFixed(3)),
+      hasAudio: (parsed.streams ?? []).some((s) => s.codec_type === "audio"),
+    };
+  } catch {
+    return { duration: 0, hasAudio: false };
+  }
+}
+
+const tail = (s, n = 25) =>
+  String(s || "").trimEnd().split("\n").slice(-n).join("\n");

--- a/cli/commands/deliver.mjs
+++ b/cli/commands/deliver.mjs
@@ -1,11 +1,15 @@
 /**
- * brag deliver — render, pick a poster, bake it as frame zero, write the manifest.
+ * brag deliver — render, pick a poster, attach it, write the manifest.
  *
- * The poster is not an afterthought. A bare .mp4 has no poster attribute, and
- * every platform that regenerates thumbnails server-side grabs frame 0 — so an
+ * The poster is not an afterthought. A bare .mp4 has no poster attribute, so an
  * unhandled render advertises itself with whatever happens to be at t=0, which
  * on a well-made video is usually an empty background mid-fade. Brag picks the
- * strongest settled moment it can name and makes frame 0 *be* that frame.
+ * strongest settled moment it can name and attaches it as cover art, and writes
+ * it beside the file for anywhere that wants an image rather than a stream.
+ *
+ * It is not painted onto frame 0. Doing that shows a frame from the middle of
+ * the film in front of its own opening, and the alternative to a weak first
+ * frame is a stronger opening scene, not a splice.
  */
 
 import { spawnSync } from "node:child_process";
@@ -78,20 +82,27 @@ export async function run({ flags }) {
   run_(["-v", "error", "-ss", String(poster.at), "-i", mp4, "-frames:v", "1", "-q:v", "2", jpg, "-y"]);
   if (!fs.existsSync(jpg)) throw gateError("ffmpeg produced no poster frame");
 
-  /* Replace only frame 0's pixels; every other frame, the duration and the
-     audio pass through untouched. At 30fps the poster shows for 1/30s. */
-  const baked = `${finalMp4}.tmp.mp4`;
+  /* Attached as cover art, not painted over frame 0.
+     Overlaying the poster onto the first frame is the obvious way to do this
+     and it puts a frame from the middle of the film in front of its own
+     opening for 1/30s. Every code gate passes that — nothing is malformed —
+     and a person watching sees a flash of a later scene before the video
+     starts. A blind reviewer called it a glitch, which is what it is.
+     An attached_pic stream is what players and metadata readers look for, and
+     it leaves the film's own first frame alone. Copying the streams rather
+     than re-encoding also means delivery cannot degrade the render. */
+  const withCover = `${finalMp4}.tmp.mp4`;
   run_([
     "-y", "-v", "error",
     "-i", mp4,
     "-i", jpg,
-    "-filter_complex", "[0:v][1:v]overlay=0:0:enable='eq(n,0)'[v]",
-    "-map", "[v]", "-map", "0:a?",
-    "-c:v", "libx264", "-crf", "18", "-preset", "slow", "-pix_fmt", "yuv420p",
-    "-c:a", "copy", "-movflags", "+faststart",
-    baked,
+    "-map", "0", "-map", "1",
+    "-c", "copy", "-c:v:1", "mjpeg",
+    "-disposition:v:1", "attached_pic",
+    "-movflags", "+faststart",
+    withCover,
   ]);
-  fs.renameSync(baked, finalMp4);
+  fs.renameSync(withCover, finalMp4);
 
   const finalProbe = probe(finalMp4);
   if (Math.abs(finalProbe.duration - probed.duration) > 0.1) {
@@ -137,7 +148,7 @@ export async function run({ flags }) {
     [
       `Delivered ${variant}.`,
       `  ${path.relative(project.targetRoot, finalMp4)}  ${(manifest.bytes / 1e6).toFixed(1)} MB · ${manifest.duration}s${manifest.has_audio ? " · audio" : " · silent"}`,
-      `  poster baked as frame 0 from ${poster.at}s (${poster.why})`,
+      `  poster attached as cover art from ${poster.at}s (${poster.why})`,
       `  ${path.relative(project.targetRoot, path.join(deliveryDir, `${variant}.share-copy.txt`))}`,
     ],
   );

--- a/cli/commands/direct.mjs
+++ b/cli/commands/direct.mjs
@@ -1,0 +1,7 @@
+/**
+ * brag direct — not implemented yet.
+ */
+
+import { notYet } from "../lib/stub.mjs";
+
+export const run = notYet("direct", "Phase 3", "chooses the visual world and derives frame.md, the design truth");

--- a/cli/commands/doctor.mjs
+++ b/cli/commands/doctor.mjs
@@ -1,0 +1,121 @@
+/**
+ * brag doctor — is this environment fit to produce a video?
+ *
+ * HyperFrames is a moving upstream. Brag reads its rule indices at runtime
+ * rather than vendoring them, which is correct but means a renamed file or a
+ * changed index format degrades brag silently: an empty vocabulary still
+ * "works", it just produces compositions that cite nothing. Doctor's job is to
+ * turn that class of failure into an exit code.
+ */
+
+import {
+  HYPERFRAMES_PIN,
+  blueprintIds,
+  ffmpegAvailable,
+  ffprobeAvailable,
+  hyperframesVersion,
+  requiredPaths,
+  ruleIds,
+  skillsRoot,
+  transitionNames,
+} from "../lib/hyperframes.mjs";
+import { EXIT, exists, isJsonMode, emitJson, say, warn } from "../lib/util.mjs";
+
+/** An index that parses to fewer than this is a format change, not a small library. */
+const FLOOR = { rules: 20, blueprints: 8, transitions: 4 };
+
+export async function run({ flags }) {
+  const checks = [];
+  const add = (id, ok, note, { fatal = true } = {}) =>
+    checks.push({ id, ok, note, fatal });
+
+  /* -------------------------------------------------- node + media tooling */
+
+  const major = Number(process.versions.node.split(".")[0]);
+  add("node", major >= 22, `node ${process.versions.node} (need >= 22)`);
+  add("ffmpeg", ffmpegAvailable(), ffmpegAvailable() ? "on PATH" : "not on PATH — rendering and poster extraction need it");
+  add("ffprobe", ffprobeAvailable(), ffprobeAvailable() ? "on PATH" : "not on PATH — render verification needs it");
+
+  /* -------------------------------------------------- the skill pack */
+
+  const root = skillsRoot();
+  add("skills-root", Boolean(root), root ?? "no directory contains hyperframes-core and hyperframes-animation");
+
+  if (root) {
+    for (const { id, file, why } of requiredPaths(root)) {
+      add(`path:${id}`, exists(file), exists(file) ? file : `missing ${file} — ${why}`);
+    }
+
+    /* ------------------------------------------------ vocabulary size */
+
+    try {
+      const rules = await ruleIds();
+      add(
+        "vocab:rules",
+        rules.size >= FLOOR.rules,
+        `${rules.size} motion rules` +
+          (rules.size >= FLOOR.rules ? "" : ` — expected at least ${FLOOR.rules}; the index format probably changed`),
+      );
+    } catch (e) {
+      add("vocab:rules", false, e.message);
+    }
+
+    try {
+      const blueprints = blueprintIds(root);
+      add(
+        "vocab:blueprints",
+        blueprints.size >= FLOOR.blueprints,
+        `${blueprints.size} scene blueprints` +
+          (blueprints.size >= FLOOR.blueprints ? "" : ` — expected at least ${FLOOR.blueprints}`),
+      );
+    } catch (e) {
+      add("vocab:blueprints", false, e.message);
+    }
+
+    try {
+      const transitions = transitionNames(root);
+      add(
+        "vocab:transitions",
+        transitions.size >= FLOOR.transitions,
+        `${transitions.size} registry transitions` +
+          (transitions.size >= FLOOR.transitions ? "" : ` — expected at least ${FLOOR.transitions}`),
+      );
+    } catch (e) {
+      add("vocab:transitions", false, e.message);
+    }
+  }
+
+  /* -------------------------------------------------- hyperframes itself */
+
+  const version = flags.quick ? null : hyperframesVersion();
+  if (!flags.quick) {
+    add(
+      "hyperframes",
+      Boolean(version),
+      version ? `${HYPERFRAMES_PIN} responds (${version})` : `\`npx ${HYPERFRAMES_PIN}\` did not respond`,
+      { fatal: false },
+    );
+  }
+
+  /* -------------------------------------------------- report */
+
+  const failed = checks.filter((c) => !c.ok && c.fatal);
+  const soft = checks.filter((c) => !c.ok && !c.fatal);
+
+  if (isJsonMode()) {
+    emitJson({ ok: failed.length === 0, checks });
+  } else {
+    for (const c of checks) {
+      const mark = c.ok ? "ok  " : c.fatal ? "FAIL" : "warn";
+      say(`  ${mark}  ${c.id.padEnd(22)} ${c.note}`);
+    }
+    say("");
+    if (failed.length === 0 && soft.length === 0) say("Environment is fit.");
+    else if (failed.length === 0) say("Usable, with warnings above.");
+    else say(`${failed.length} blocking problem${failed.length === 1 ? "" : "s"} above.`);
+  }
+
+  for (const c of soft) warn(`${c.id}: ${c.note}`);
+
+  return failed.length === 0 ? EXIT.OK : EXIT.ENV;
+}

--- a/cli/commands/frames.mjs
+++ b/cli/commands/frames.mjs
@@ -1,0 +1,71 @@
+/**
+ * brag frames — build the frame packets and say which frames still need designing.
+ *
+ * This is where the boundary actually lands. Brag decides what the video
+ * argues, what must be readable, what must be proven and how each cut travels.
+ * It does not decide what a frame looks like — HyperFrames owns a catalogue of
+ * motion rules and scene blueprints, and a frame worker reading that catalogue
+ * designs a far better frame than a compiler emitting a flexbox ever will.
+ *
+ * The compiler's own per-scene markup is a scaffold and is treated as one: a
+ * scene with a designed frame mounts it, a scene without falls back, and
+ * `brag compose` never overwrites a frame a worker has authored.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { buildFramePackets } from "../frame-packets.mjs";
+import { frameFile, withStarts } from "../lib/compile/targets.mjs";
+import { resolveProject } from "../lib/state.mjs";
+import { EXIT, gateError, report } from "../lib/util.mjs";
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  project.load();
+
+  const variant = flags.variant ?? "landscape";
+  const dir = project.path("compositions", variant);
+  if (!fs.existsSync(path.join(dir, "STORYBOARD.md"))) {
+    throw gateError(
+      `no composition at compositions/${variant}. Run \`brag compose\` first — the packets are built from its STORYBOARD.md.`,
+    );
+  }
+
+  const graph = JSON.parse(fs.readFileSync(path.join(dir, "scene_graph.json"), "utf8"));
+  const scenes = withStarts(graph);
+
+  const packets = await buildFramePackets({ projectDir: dir });
+
+  const work = scenes.map((scene, i) => {
+    const rel = path.posix.join("compositions", "frames", frameFile(i, scene));
+    const abs = path.join(dir, rel.split("/").join(path.sep));
+    const exists = fs.existsSync(abs);
+    const outline = exists && /^<!-- outline frame:/.test(fs.readFileSync(abs, "utf8").trimStart());
+    const id = path.basename(rel, ".html");
+    return {
+      frame_id: id,
+      scene: scene.id,
+      designed: exists && !outline,
+      packet: path.posix.join(".hyperframes", "frame-packets", `${id}.md`),
+      write_to: path.posix.join(`compositions/${variant}`, rel),
+    };
+  });
+
+  const todo = work.filter((w) => !w.designed);
+
+  report(
+    { ok: true, project_dir: dir, role: ".hyperframes/frame-packets/_role.md", frames: work, packets: packets.length },
+    [
+      `${packets.length} packet(s) in ${path.relative(project.targetRoot, dir)}/.hyperframes/frame-packets/`,
+      todo.length
+        ? `${todo.length} frame(s) still need designing:`
+        : "Every frame has been designed. Run `brag compose` to assemble them.",
+      ...todo.map((w) => `  ${w.frame_id.padEnd(16)} → ${w.write_to}`),
+      todo.length
+        ? "\nDispatch one worker per frame. Each reads _role.md and its own packet,\n" +
+          "and writes only its assigned file. Then re-run `brag compose`."
+        : "",
+    ].filter(Boolean),
+  );
+  return EXIT.OK;
+}

--- a/cli/commands/init.mjs
+++ b/cli/commands/init.mjs
@@ -1,0 +1,33 @@
+/**
+ * brag init — create the working directory for a product.
+ */
+
+import path from "node:path";
+import { resolveProject } from "../lib/state.mjs";
+import { EXIT, report, slug } from "../lib/util.mjs";
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  const name = flags.name ?? path.basename(project.targetRoot);
+
+  const created = project.init({
+    name,
+    targetSurfaceHint: flags.surface ?? null,
+    force: flags.force,
+  });
+
+  report(
+    { ok: true, project: created, dir: project.dir },
+    [
+      `Created ${path.relative(process.cwd(), project.dir) || "brag/"} for "${name}".`,
+      "",
+      "Next: brag inspect --emit",
+    ],
+  );
+  return EXIT.OK;
+}
+
+export const describe = {
+  summary: "create brag/ in the current project",
+  slugFor: slug,
+};

--- a/cli/commands/inspect.mjs
+++ b/cli/commands/inspect.mjs
@@ -1,0 +1,176 @@
+/**
+ * brag inspect — classify the product surface and extract verified truth.
+ *
+ * Two phases. `--emit` runs the deterministic scan and writes a task spec.
+ * `--accept` validates the returned product model and, more importantly,
+ * re-checks it against the filesystem: a source that does not exist, or a
+ * verbatim string that is not actually in the file it claims, fails here
+ * rather than at render time.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { scanProduct } from "../lib/inspect/scan.mjs";
+import { resolveProject } from "../lib/state.mjs";
+import { acceptTaskAnswer, emitTaskSpec } from "../lib/taskspec.mjs";
+import { EXIT, gateError, report, warn } from "../lib/util.mjs";
+
+const TASK = "product_model";
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  project.load();
+  return flags.accept ? accept(project) : emit(project);
+}
+
+/* ------------------------------------------------------------------ emit */
+
+function emit(project) {
+  const signals = scanProduct(project.targetRoot);
+  project.write("signals.json", signals);
+
+  const best = signals.surface.best;
+  const { specPath } = emitTaskSpec({
+    project,
+    name: TASK,
+    title: "Build the product model",
+    objective:
+      "Establish what this product is, who it is for, and exactly which claims a video is " +
+      "allowed to make about it. Everything downstream — concepts, scenes, the fidelity " +
+      "check — resolves against this document, so a claim with no source is worse than a " +
+      "missing claim.",
+    instructions: [
+      "Read the scan below, then read the files it points at. The scan finds signals; it does not understand the product.",
+      "Classify `surface_type`. The scan's ranking is evidence, not a verdict — override it if the evidence is thin, but say why in your reply to the user.",
+      "For a `cli` surface, treat the terminal as the product interface, not as supporting material. The same holds for an `api` and its request/response exchange, and a `library` and its call site.",
+      "Write `problem` in the user's terms, not the feature's absence. \"Context is lost when switching agents\" is a problem; \"lacks a context store\" is not.",
+      "For every claim the video might make, add a `proof` entry with real evidence and an honest `strength`. Prefer `measured` and `demonstrated`; mark anything you inferred as `inferred`.",
+      "List `visual_surfaces` — the things that can actually be put on screen — and how each would be captured.",
+      "Extract `verbatim_copy`: strings that must appear exactly, each with the file it came from. Set `whitespace_significant` for aligned CLI output, trees and code.",
+      "Fill `forbidden_claims` with anything true-adjacent but unsupported, and anything the project explicitly does not claim about itself.",
+      "If the project ships a logo, check whether it survives on a dark background and record `logo_usable_on_dark`.",
+    ],
+    schemaName: "product_model",
+    context: signals,
+    rejects: [
+      "A `proof` entry whose evidence file does not exist.",
+      "A `verbatim_copy` string that is not byte-for-byte present in its stated source file.",
+      "`surface_type: \"mixed\"` without `primary_surface`.",
+      "Marketing language in `one_line` or `problem`. Use the project's own vocabulary.",
+    ],
+  });
+
+  report(
+    {
+      ok: true,
+      mode: "emit",
+      spec: specPath,
+      answer: project.answerPath(TASK),
+      surface_guess: best,
+      signals_path: project.path("signals.json"),
+    },
+    [
+      `Scanned ${signals.file_count} files.`,
+      best
+        ? `  surface signals: ${signals.surface.scored.map((s) => `${s.surface}(${s.score})`).join("  ")}`
+        : "  no strong surface signal — classification is entirely yours",
+      signals.git ? `  ${signals.git.recent_commits.length} commits of real history available` : "",
+      `  ${signals.candidate_commands.length} candidate commands, ${signals.palette.length} palette entries`,
+      "",
+      `Read ${path.relative(project.targetRoot, specPath)}, write the JSON it asks for, then:`,
+      "  brag inspect --accept",
+    ].filter(Boolean),
+  );
+  return EXIT.OK;
+}
+
+/* ------------------------------------------------------------------ accept */
+
+function accept(project) {
+  const model = acceptTaskAnswer({ project, name: TASK, schemaName: "product_model" });
+  const problems = [];
+  const root = project.targetRoot;
+  const fileOf = (src) => path.join(root, src.file);
+
+  /* Every source must exist. A model that cites a file it invented is exactly
+     the failure this stage exists to prevent. */
+  const checkSource = (src, label) => {
+    if (!fs.existsSync(fileOf(src))) problems.push(`${label} cites ${src.file}, which does not exist`);
+  };
+
+  for (const p of model.proof) {
+    for (const ev of p.evidence) checkSource(ev, `proof "${p.id}"`);
+  }
+  for (const v of model.verbatim_copy) checkSource(v.source, `verbatim "${v.id}"`);
+  if (model.identity?.logo) checkSource(model.identity.logo, "identity.logo");
+
+  /* Verbatim strings must actually be verbatim. */
+  for (const v of model.verbatim_copy) {
+    const abs = fileOf(v.source);
+    if (!fs.existsSync(abs)) continue;
+    let text;
+    try {
+      text = fs.readFileSync(abs, "utf8");
+    } catch {
+      continue;
+    }
+    if (text.includes(v.text)) continue;
+    const collapsed = text.replace(/\s+/g, " ");
+    if (collapsed.includes(v.text.replace(/\s+/g, " ").trim())) {
+      problems.push(
+        `verbatim "${v.id}" matches ${v.source.file} only after collapsing whitespace — ` +
+          "fix the text, because the fidelity check compares exactly",
+      );
+    } else {
+      problems.push(`verbatim "${v.id}" is not present in ${v.source.file}`);
+    }
+  }
+
+  if (model.surface_type === "mixed" && !model.primary_surface) {
+    problems.push('surface_type is "mixed" but primary_surface is not set');
+  }
+
+  /* Classification disagreement is a warning: the scan only counts files,
+     the model actually read them. */
+  const signals = project.read("signals.json", { optional: true });
+  const best = signals?.surface?.best;
+  if (best && best !== model.surface_type && model.surface_type !== "mixed") {
+    warn(
+      `scan ranked "${best}" highest but the model says "${model.surface_type}". ` +
+        "That may be right — say why in your reply.",
+    );
+  }
+
+  if (problems.length) {
+    throw gateError(
+      "the product model does not hold up against the filesystem:\n" +
+        problems.map((p) => `  - ${p}`).join("\n") +
+        `\n\nFix ${path.relative(root, project.answerPath(TASK))} and re-run \`brag inspect --accept\`.`,
+    );
+  }
+
+  project.write("product_model.json", {
+    ...model,
+    generated_at: model.generated_at ?? new Date().toISOString(),
+  });
+
+  const measured = model.proof.filter((p) => p.strength === "measured").length;
+  report(
+    {
+      ok: true,
+      mode: "accept",
+      surface_type: model.surface_type,
+      proof_count: model.proof.length,
+      verbatim_count: model.verbatim_copy.length,
+      path: project.path("product_model.json"),
+    },
+    [
+      `Recorded product_model.json — surface: ${model.surface_type}`,
+      `  ${model.proof.length} proofs (${measured} measured), ${model.verbatim_copy.length} verbatim strings, all sources verified`,
+      `  ${model.visual_surfaces.length} visual surfaces`,
+      "",
+      "Next: brag position --emit",
+    ],
+  );
+  return EXIT.OK;
+}

--- a/cli/commands/position.mjs
+++ b/cli/commands/position.mjs
@@ -1,0 +1,147 @@
+/**
+ * brag position — audience, angle, and the claim-to-source map.
+ *
+ * The gate here is mechanical: every claim the video intends to make must name
+ * a proof id that exists in the product model. That is the difference between
+ * a video that is persuasive and one that is defensible, and it is checked in
+ * code rather than trusted.
+ */
+
+import path from "node:path";
+import { resolveProject } from "../lib/state.mjs";
+import { acceptTaskAnswer, emitTaskSpec } from "../lib/taskspec.mjs";
+import { EXIT, gateError, report } from "../lib/util.mjs";
+
+const TASK = "positioning";
+const truncate = (s, n = 60) => (s.length > n ? `${s.slice(0, n)}…` : s);
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  project.load();
+  return flags.accept ? accept(project) : emit(project);
+}
+
+function emit(project) {
+  const model = project.read("product_model.json");
+
+  const { specPath } = emitTaskSpec({
+    project,
+    name: TASK,
+    title: "Position the product",
+    objective:
+      "Decide who this video is for, the one sentence it argues, and which claims it will " +
+      "make. Each claim must name a proof id from the product model — this is what stops a " +
+      "good-sounding line entering the edit unsupported.",
+    instructions: [
+      "Pick the narrowest audience the video can serve well. A video for everyone directs like a video for no one.",
+      "Write `angle` as one sentence the video argues, not a summary of features. It should be arguable — something a reasonable person could disagree with before watching.",
+      "List every claim the video will make, each bound to a `proof_ref`. If a claim you want has no proof, either drop it or go back and add the proof with real evidence.",
+      "Set `verbatim: true` on claims that must be shown in the product's own words rather than paraphrased.",
+      "`destination` changes direction: a feed autoplay cannot assume sound, a README embed can assume patience.",
+      "Use `avoid` for framings that would land but are wrong — categories the product is not in, comparisons it does not want to invite.",
+    ],
+    schemaName: "positioning",
+    context: {
+      product: {
+        name: model.name,
+        one_line: model.one_line,
+        surface_type: model.surface_type,
+        problem: model.problem,
+        mechanism: model.mechanism,
+      },
+      available_proofs: model.proof.map((p) => ({
+        id: p.id,
+        claim: p.claim,
+        strength: p.strength,
+        shows_well: p.shows_well ?? null,
+      })),
+      forbidden_claims: model.forbidden_claims,
+    },
+    rejects: [
+      "A claim whose `proof_ref` is not one of the available proof ids listed above.",
+      "A claim that restates or paraphrases anything in `forbidden_claims`.",
+      "An `angle` that no one could disagree with.",
+    ],
+  });
+
+  report(
+    { ok: true, mode: "emit", spec: specPath, answer: project.answerPath(TASK) },
+    [
+      `${model.proof.length} proofs available to build claims from.`,
+      "",
+      `Read ${path.relative(project.targetRoot, specPath)}, write the JSON, then:`,
+      "  brag position --accept",
+    ],
+  );
+  return EXIT.OK;
+}
+
+function accept(project) {
+  const positioning = acceptTaskAnswer({ project, name: TASK, schemaName: "positioning" });
+  const model = project.read("product_model.json");
+
+  const known = new Set(model.proof.map((p) => p.id));
+  const problems = [];
+
+  for (const claim of positioning.claims) {
+    if (!known.has(claim.proof_ref)) {
+      problems.push(
+        `claim "${truncate(claim.text)}" cites proof "${claim.proof_ref}", which is not in the product model ` +
+          `(have: ${[...known].join(", ")})`,
+      );
+    }
+  }
+
+  /* A forbidden claim reappearing as a positioning claim is the most likely
+     route by which an unsupported line survives into the edit. */
+  const normalise = (s) =>
+    s.toLowerCase().replace(/[^a-z0-9 ]+/g, " ").replace(/\s+/g, " ").trim();
+  for (const forbidden of model.forbidden_claims ?? []) {
+    const f = normalise(forbidden);
+    if (!f) continue;
+    for (const claim of positioning.claims) {
+      if (normalise(claim.text).includes(f)) {
+        problems.push(`claim "${truncate(claim.text)}" restates a forbidden claim: "${forbidden}"`);
+      }
+    }
+  }
+
+  if (problems.length) {
+    throw gateError(
+      "positioning does not resolve against the product model:\n" +
+        problems.map((p) => `  - ${p}`).join("\n") +
+        `\n\nFix ${path.relative(project.targetRoot, project.answerPath(TASK))} and re-run \`brag position --accept\`.`,
+    );
+  }
+
+  const unusedStrong = model.proof.filter(
+    (p) => p.strength === "measured" && !positioning.claims.some((c) => c.proof_ref === p.id),
+  );
+
+  project.write("positioning.json", {
+    ...positioning,
+    generated_at: positioning.generated_at ?? new Date().toISOString(),
+  });
+
+  report(
+    {
+      ok: true,
+      mode: "accept",
+      claims: positioning.claims.length,
+      unused_measured_proofs: unusedStrong.map((p) => p.id),
+      path: project.path("positioning.json"),
+    },
+    [
+      `Recorded positioning.json — ${positioning.claims.length} claims, every one bound to a proof.`,
+      `  angle: ${positioning.angle}`,
+      unusedStrong.length
+        ? `  note: ${unusedStrong.length} measured proof(s) unused (${unusedStrong
+            .map((p) => p.id)
+            .join(", ")}) — measured evidence is the strongest thing you have`
+        : "",
+      "",
+      "Next: brag concepts --emit",
+    ].filter(Boolean),
+  );
+  return EXIT.OK;
+}

--- a/cli/commands/review.mjs
+++ b/cli/commands/review.mjs
@@ -25,7 +25,7 @@ import {
   detectUnreadableCopy,
   summarize,
 } from "../lib/detect/index.mjs";
-import { checkFidelity, extractRenderedText } from "../lib/detect/fidelity.mjs";
+import { checkFidelity, extractRenderedText, extractRenderedTree } from "../lib/detect/fidelity.mjs";
 import { scoreNarrative } from "../lib/detect/narrative.mjs";
 import { acceptTaskAnswer, emitTaskSpec } from "../lib/taskspec.mjs";
 import { hyperframes } from "../lib/hyperframes.mjs";
@@ -199,8 +199,12 @@ export async function run({ flags, args }) {
       context: {
         contact_sheet: layers.visual?.contact_sheet ?? null,
         frames: (bundle.frames ?? []).map((f) => ({ at: f.at, file: f.file })),
-        text_on_screen: extractRenderedText(
+        text_on_screen: extractRenderedTree(
           fs.readFileSync(project.path("compositions", variant, "index.html"), "utf8"),
+          (src) => {
+            const abs = project.path("compositions", variant, ...src.split("/"));
+            return fs.existsSync(abs) ? fs.readFileSync(abs, "utf8") : null;
+          },
         ).map((t) => t.text),
       },
       rejects: [
@@ -218,7 +222,12 @@ export async function run({ flags, args }) {
   if (variant) {
     const htmlPath = project.path("compositions", variant, "index.html");
     if (fs.existsSync(htmlPath)) {
-      const rendered = extractRenderedText(fs.readFileSync(htmlPath, "utf8"));
+      /* The index holds the mounts; the copy lives in the frames they point
+         at, so the whole tree gets read or the layer checks nothing. */
+      const rendered = extractRenderedTree(fs.readFileSync(htmlPath, "utf8"), (src) => {
+        const abs = project.path("compositions", variant, ...src.split("/"));
+        return fs.existsSync(abs) ? fs.readFileSync(abs, "utf8") : null;
+      });
       const manifest = project.read("captures/capture_manifest.json", { optional: true });
       const captureLines = (manifest?.sessions ?? []).flatMap((entry) => [
         ...(entry.lines ?? []),

--- a/cli/commands/review.mjs
+++ b/cli/commands/review.mjs
@@ -1,0 +1,329 @@
+/**
+ * brag review — the verification layers, as an exit code.
+ *
+ * Layer 1 is structural: `hyperframes check` plus the motion sidecar, run
+ * against the composition.
+ * Layer 2 is visual: the watch bundle's frames, measured.
+ *
+ * Layers 3 (narrative) and 4 (product fidelity) arrive in a later phase and
+ * are reported as `pending` rather than silently counted as passing — a review
+ * that quietly skips its hardest layers is worse than one that admits it.
+ *
+ * The whole point is that `check` passing does not mean the video is right.
+ * This session has already produced two proofs of that: a composition whose
+ * terminal was half invisible, and a poster showing a scene's second line with
+ * the first still missing. Both passed every structural gate.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { tightScenes } from "../lib/compile/targets.mjs";
+import {
+  detectCaptionZone,
+  detectFlatFrames,
+  detectRepeatedLayouts,
+  detectUnreadableCopy,
+  summarize,
+} from "../lib/detect/index.mjs";
+import { checkFidelity, extractRenderedText } from "../lib/detect/fidelity.mjs";
+import { scoreNarrative } from "../lib/detect/narrative.mjs";
+import { acceptTaskAnswer, emitTaskSpec } from "../lib/taskspec.mjs";
+import { hyperframes } from "../lib/hyperframes.mjs";
+import { applyTiming, solveTiming } from "../lib/solve/timing.mjs";
+import { resolveProject } from "../lib/state.mjs";
+import { buildBundle } from "../lib/watch/bundle.mjs";
+import { EXIT, ensureDir, isJsonMode, emitJson, gateError, say, writeJson } from "../lib/util.mjs";
+import { probeDuration, resolveVideo } from "./watch.mjs";
+
+export async function run({ flags, args }) {
+  const project = resolveProject(flags);
+  project.load();
+
+  const index = project.read("compositions/index.json", { optional: true });
+  /* Newest first, so a bare `brag review` looks at what was just built rather
+     than whichever variant happens to sort first. */
+  const variant =
+    flags.variant ??
+    Object.entries(index?.variants ?? {})
+      .sort((a, b) => String(b[1].compiled_at ?? "").localeCompare(String(a[1].compiled_at ?? "")))
+      .map(([name]) => name)[0] ??
+    null;
+
+  /* The graph this variant was compiled from. Reading the project's current
+     graph instead made `review --variant` report the same findings for every
+     variant, which is worse than not checking: it looks like verification. */
+  const rawGraph =
+    (variant && project.read(`compositions/${variant}/scene_graph.json`, { optional: true })) ??
+    project.read("scene_graph.json");
+  const plan = solveTiming(rawGraph);
+  const graph = applyTiming(rawGraph, plan);
+
+  const findings = [];
+  const layers = {};
+
+  /* ------------------------------------------------------- L1 structural */
+
+  if (variant) {
+    const compDir = project.path("compositions", variant);
+    say(`Layer 1 — checking ${variant}…`);
+    const check = hyperframes(["check"], { cwd: compDir });
+    layers.structural = {
+      ok: check.status === 0,
+      detail: check.status === 0 ? "hyperframes check passed" : tail(check.stdout || check.stderr),
+    };
+    if (check.status !== 0) {
+      findings.push({
+        code: "structural_check_failed",
+        scene: null,
+        at: null,
+        message: "hyperframes check reported errors (layout, contrast, runtime or motion)",
+        fix: "read the check output below and fix what it names",
+      });
+    }
+  } else {
+    layers.structural = { ok: false, detail: "no compiled variant to check" };
+    findings.push({
+      code: "nothing_compiled",
+      scene: null,
+      at: null,
+      message: "there is no compiled composition to review",
+      fix: "run `brag compose`",
+    });
+  }
+
+  /* Timing is knowable without rendering, so it is checked whether or not a
+     video exists yet. */
+  findings.push(...detectUnreadableCopy(tightScenes(graph)));
+
+  /* ------------------------------------------------------- L2 visual */
+
+  let bundle = null;
+  try {
+    const video = resolveVideo({ project, flags, args, variant });
+    const duration = probeDuration(video);
+    const outDir = ensureDir(project.path("reviews", path.basename(video, path.extname(video))));
+    say(`Layer 2 — watching ${path.basename(video)} (${duration}s)…`);
+
+    bundle = buildBundle({ video, graph, duration, outDir });
+    writeJson(path.join(outDir, "watch.json"), {
+      schema: "brag.watch_bundle/1",
+      video: path.relative(project.dir, video).split(path.sep).join("/"),
+      duration,
+      frames: bundle.frames,
+    });
+
+    findings.push(...detectFlatFrames(bundle.frames));
+    findings.push(...detectCaptionZone(bundle.frames));
+    findings.push(...detectRepeatedLayouts(bundle.frames));
+
+    layers.visual = {
+      ok: true,
+      detail: `${bundle.frames.length} frames sampled`,
+      contact_sheet: bundle.contactSheet
+        ? path.relative(project.dir, bundle.contactSheet).split(path.sep).join("/")
+        : null,
+    };
+  } catch (e) {
+    layers.visual = { ok: false, detail: e.message };
+    findings.push({
+      code: "no_render_to_review",
+      scene: null,
+      at: null,
+      message: e.message,
+      fix: "run `brag deliver`, or pass a path to a rendered file",
+    });
+  }
+
+  /* ------------------------------------------------------- L3 narrative */
+
+  const narrativeAnswer =
+    flags.narrative || flags["accept-narrative"]
+      ? project.read("tasks/review_narrative.json", { optional: true })
+      : null;
+
+  if (narrativeAnswer) {
+    const scored = scoreNarrative({
+      answers: narrativeAnswer,
+      model: project.read("product_model.json"),
+      positioning: project.read("positioning.json", { optional: true }),
+      graph,
+    });
+    /* Reported, never gating. Until this grader's accuracy has been measured
+       against labelled fixtures, letting it fail a delivery would trade a
+       known-good video for an unmeasured opinion. */
+    layers.narrative = {
+      ok: scored.agreement >= 0.7,
+      gating: false,
+      agreement: scored.agreement,
+      detail:
+        `${(scored.agreement * 100).toFixed(0)}% agreement with the plan` +
+        (scored.findings.length ? ` — ${scored.findings.length} observation(s), reported not gating` : ""),
+      checks: scored.checks,
+      observations: scored.findings,
+    };
+  } else if (bundle) {
+    layers.narrative = {
+      ok: null,
+      detail: "not run — `brag review --narrative` writes the spec for a blind reviewer",
+    };
+  } else {
+    layers.narrative = { ok: null, detail: "no render to review" };
+  }
+
+  /* The spec deliberately carries the frames and the rendered text and nothing
+     else. Handing over the scene graph would produce a reviewer that grades
+     the plan rather than the film. */
+  if (flags.narrative && bundle) {
+    const { specPath } = emitTaskSpec({
+      project,
+      name: "review_narrative",
+      title: "Watch this video and say what you took away",
+      objective:
+        "You are seeing a rendered video as a stranger would: a sheet of frames in order, and " +
+        "the text that appeared on screen. You have not been told what it is for, and you must " +
+        "not go looking. Answer only from what is in front of you.",
+      instructions: [
+        "Open the contact sheet and the individual frames listed below, in order.",
+        "Say what product this is for. If you cannot tell, say so plainly — that answer is more useful than a guess.",
+        "Say what problem it claims to solve, in your words.",
+        "List the evidence that was actually shown, as distinct from things merely asserted.",
+        "List the distinct moments you could make out, in order.",
+        "List anything stated that nothing on screen backed up.",
+        "Say whether the story survives with the sound off, and why.",
+        "List anything you could not read in the time it was up.",
+        "Say what a convinced viewer is meant to do next.",
+        "Do not read the scene graph, the brief, the storyboard, or any other file in this project. If you have already seen them, say so instead of answering.",
+        "When the JSON is written, stop. Someone else runs `brag review --accept-narrative` to record it — you are not expected to find that command, and looking for it would mean browsing the project you were asked to stay out of.",
+      ],
+      schemaName: "review_narrative",
+      context: {
+        contact_sheet: layers.visual?.contact_sheet ?? null,
+        frames: (bundle.frames ?? []).map((f) => ({ at: f.at, file: f.file })),
+        text_on_screen: extractRenderedText(
+          fs.readFileSync(project.path("compositions", variant, "index.html"), "utf8"),
+        ).map((t) => t.text),
+      },
+      rejects: [
+        "An answer that repeats the project's own vocabulary without it having appeared on screen.",
+        "Confirming what you assume the video was trying to do rather than what it did.",
+      ],
+    });
+    say("");
+    say(`Blind review spec: ${path.relative(project.targetRoot, specPath)}`);
+    say("Answer it without reading the plan, then re-run with --accept-narrative.");
+  }
+
+  /* ------------------------------------------------------- L4 fidelity */
+
+  if (variant) {
+    const htmlPath = project.path("compositions", variant, "index.html");
+    if (fs.existsSync(htmlPath)) {
+      const rendered = extractRenderedText(fs.readFileSync(htmlPath, "utf8"));
+      const manifest = project.read("captures/capture_manifest.json", { optional: true });
+      const captureLines = (manifest?.sessions ?? []).flatMap((entry) => [
+        ...(entry.lines ?? []),
+        entry.display_command,
+      ]);
+
+      const fidelity = checkFidelity({
+        rendered,
+        model: project.read("product_model.json"),
+        positioning: project.read("positioning.json", { optional: true }),
+        captureLines: captureLines.filter(Boolean),
+      });
+
+      findings.push(...fidelity.findings);
+      layers.fidelity = {
+        ok: fidelity.findings.length === 0,
+        detail: `${fidelity.resolved}/${fidelity.checked} rendered strings resolve to a source`,
+      };
+    } else {
+      layers.fidelity = { ok: false, detail: "no compiled composition to read" };
+    }
+  } else {
+    layers.fidelity = { ok: null, detail: "nothing compiled" };
+  }
+
+  /* ------------------------------------------------------- report */
+
+  const failed = findings.length > 0;
+  const report_ = {
+    schema: "brag.review_report/1",
+    variant,
+    ok: !failed,
+    layers,
+    findings,
+    summary: summarize(findings),
+    reviewed_at: new Date().toISOString(),
+  };
+
+  const reviewsDir = ensureDir(project.path("reviews"));
+  writeJson(path.join(reviewsDir, "latest.json"), report_);
+  fs.writeFileSync(
+    path.join(reviewsDir, "latest.md"),
+    renderMarkdown(report_),
+  );
+
+  if (isJsonMode()) {
+    emitJson(report_);
+  } else {
+    say("");
+    for (const [name, layer] of Object.entries(layers)) {
+      const mark = layer.ok === null ? "…" : layer.ok ? "ok" : "!!";
+      say(`  ${mark}  ${name.padEnd(11)} ${layer.detail}`);
+    }
+    if (findings.length) {
+      say("");
+      for (const f of findings) {
+        say(`  ${f.code}${f.scene ? ` [${f.scene}]` : ""}${f.at !== null ? ` @${f.at}s` : ""}`);
+        say(`      ${f.message}`);
+        say(`      fix: ${f.fix}`);
+      }
+    }
+    say("");
+    say(
+      failed
+        ? `${findings.length} finding${findings.length === 1 ? "" : "s"}. Not deliverable yet.`
+        : layers.narrative.ok === null
+          ? "Nothing found. The blind narrative review has not been run — try --narrative."
+          : "Nothing found by any layer.",
+    );
+  }
+
+  if (failed) {
+    if (layers.structural.ok === false && layers.structural.detail) {
+      say("");
+      say(layers.structural.detail);
+    }
+    return EXIT.GATE;
+  }
+  return EXIT.OK;
+}
+
+/* ------------------------------------------------------------------ output */
+
+function renderMarkdown(report) {
+  const lines = [
+    `# Review — ${report.variant ?? "(uncompiled)"}`,
+    "",
+    report.ok ? "No findings from the implemented layers." : `${report.findings.length} findings.`,
+    "",
+    "| Layer | Result | Detail |",
+    "| --- | --- | --- |",
+    ...Object.entries(report.layers).map(
+      ([k, v]) => `| ${k} | ${v.ok === null ? "pending" : v.ok ? "pass" : "fail"} | ${String(v.detail).split("\n")[0]} |`,
+    ),
+    "",
+  ];
+  if (report.findings.length) {
+    lines.push("## Findings", "");
+    for (const f of report.findings) {
+      lines.push(`### \`${f.code}\`${f.scene ? ` — ${f.scene}` : ""}${f.at !== null ? ` at ${f.at}s` : ""}`);
+      lines.push("", f.message, "", `**Fix:** ${f.fix}`, "");
+    }
+  }
+  return lines.join("\n");
+}
+
+const tail = (s, n = 40) =>
+  String(s || "").trimEnd().split("\n").slice(-n).join("\n");

--- a/cli/commands/revise.mjs
+++ b/cli/commands/revise.mjs
@@ -1,0 +1,177 @@
+/**
+ * brag revise — change one thing without rebuilding everything.
+ *
+ * The value is in what does *not* change. A revision that quietly regenerates
+ * the whole film costs you every decision you had already accepted, so this
+ * takes an intent, scopes it to named scenes, and proves afterwards that every
+ * frame it did not name came out byte-identical.
+ *
+ * That proof is only possible because compiling is deterministic. It is the
+ * property the first phase was built around, and this is what it was for.
+ */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { diffFingerprints, fingerprintTree } from "../lib/determinism.mjs";
+import { resolveProject } from "../lib/state.mjs";
+import { acceptTaskAnswer, emitTaskSpec } from "../lib/taskspec.mjs";
+import { EXIT, gateError, report, say, writeJson } from "../lib/util.mjs";
+
+const TASK = "revision";
+
+export async function run({ flags, args }) {
+  const project = resolveProject(flags);
+  project.load();
+  return flags.accept ? accept(project, flags) : emit(project, args?.join(" "));
+}
+
+function emit(project, intent) {
+  if (!intent) {
+    throw gateError('say what to change: brag revise "make the opening more aggressive"');
+  }
+  const graph = project.read("scene_graph.json");
+  const concept = project.read("selected_concept.json", { optional: true });
+
+  const { specPath } = emitTaskSpec({
+    project,
+    name: TASK,
+    title: `Revise: ${intent}`,
+    objective:
+      "Apply one change to the scene graph and touch nothing else. Name the scenes you are " +
+      "changing before you change them; everything unnamed must come out of the compiler " +
+      "byte-identical, and that is checked.",
+    instructions: [
+      `The change asked for: ${intent}`,
+      "List the scene ids you intend to touch in `scenes_touched`, then give the replacement scene objects in `scenes`.",
+      "Do not renumber, reorder or rename scenes. A revision that reshuffles the film is a rewrite wearing a smaller name.",
+      "Keep every `required_proof` intact: a revision may change how a scene argues, never whether it still shows its evidence.",
+      "Obey the locked concept's visual rule and forbidden motifs — those did not change because the copy did.",
+      "If the change cannot be made within the named scenes, say so in `blocked` rather than widening the scope quietly.",
+    ],
+    schemaName: "revision",
+    context: {
+      intent,
+      concept: concept
+        ? { visual_rule: concept.visual_rule, forbidden_motifs: concept.forbidden_motifs }
+        : null,
+      scenes: graph.scenes.map((s) => ({
+        id: s.id,
+        role: s.role,
+        purpose: s.purpose,
+        duration: s.duration,
+        reading: s.reading,
+        required_proof: s.required_proof,
+      })),
+    },
+    rejects: [
+      "Touching a scene not listed in `scenes_touched`.",
+      "Dropping a `required_proof` from any scene.",
+      "Adding or removing scenes — that is a new storyboard, not a revision.",
+    ],
+  });
+
+  report(
+    { ok: true, mode: "emit", spec: specPath, intent },
+    [
+      `Revision: ${intent}`,
+      "",
+      `Read ${path.relative(project.targetRoot, specPath)}, write the JSON, then:`,
+      "  brag revise --accept",
+    ],
+  );
+  return EXIT.OK;
+}
+
+function accept(project, flags) {
+  const answer = acceptTaskAnswer({ project, name: TASK, schemaName: "revision" });
+  if (answer.blocked) {
+    throw gateError(
+      `the revision reports it cannot be made within the scenes it named: ${answer.blocked}`,
+    );
+  }
+
+  const graph = project.read("scene_graph.json");
+  const touched = new Set(answer.scenes_touched);
+  const replacements = new Map(answer.scenes.map((s) => [s.id, s]));
+
+  for (const id of replacements.keys()) {
+    if (!touched.has(id)) {
+      throw gateError(`scene "${id}" was changed but not declared in scenes_touched`);
+    }
+  }
+  const known = new Set(graph.scenes.map((s) => s.id));
+  for (const id of touched) {
+    if (!known.has(id)) throw gateError(`scenes_touched names "${id}", which is not a scene`);
+  }
+
+  const next = {
+    ...graph,
+    scenes: graph.scenes.map((scene) => {
+      const replacement = replacements.get(scene.id);
+      if (!replacement) return scene;
+      /* Proof survives a revision by construction rather than by review. */
+      return { ...scene, ...replacement, required_proof: scene.required_proof };
+    }),
+  };
+
+  const index = project.read("compositions/index.json", { optional: true });
+  const variant =
+    flags.variant ?? Object.keys(index?.variants ?? {})[0] ?? next.format?.name ?? "landscape";
+  const outDir = project.path("compositions", variant);
+
+  const before = fingerprintTree(outDir);
+  project.write("scene_graph.json", next);
+  project.write(path.join("tasks", "scene_graph.json"), next);
+
+  say(`Recompiling ${variant} after touching ${[...touched].join(", ")}…`);
+  const res = spawnSync(
+    process.execPath,
+    [
+      path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "brag.mjs"),
+      "compose",
+      "-C",
+      project.targetRoot,
+      "--variant",
+      variant,
+      "--skip-gates",
+    ],
+    { stdio: "inherit" },
+  );
+  if (res.status !== 0) return res.status ?? EXIT.GATE;
+
+  /* The whole claim of a scoped revision, checked: anything not named should
+     be identical, and a frame file belongs to the scene whose id it carries. */
+  const after = fingerprintTree(outDir);
+  const diff = diffFingerprints(before, after);
+  const strayed = diff.changed.filter((file) => {
+    if (!file.startsWith("compositions/frames/")) return false;
+    return ![...touched].some((id) => file.includes(id));
+  });
+
+  if (strayed.length) {
+    throw gateError(
+      "a scoped revision changed frames it did not name:\n" +
+        strayed.map((f) => `  - ${f}`).join("\n") +
+        "\n\nThat means the change was not really scoped, and nothing else it claims can be trusted.",
+    );
+  }
+
+  report(
+    {
+      ok: true,
+      mode: "accept",
+      intent: answer.intent,
+      touched: [...touched],
+      changed: diff.changed,
+      untouched_identical: true,
+    },
+    [
+      `Revised ${touched.size} scene(s): ${[...touched].join(", ")}`,
+      `  ${diff.changed.length} file(s) changed, and every frame outside those scenes is byte-identical.`,
+      "",
+      `Next: brag deliver --variant ${variant}`,
+    ],
+  );
+  return EXIT.OK;
+}

--- a/cli/commands/select.mjs
+++ b/cli/commands/select.mjs
@@ -1,0 +1,173 @@
+/**
+ * brag select — score the concepts and lock one.
+ *
+ * Scoring runs as its own dispatch, separate from generation, and the model
+ * rates only what it can legitimately judge. Novelty and
+ * difference-from-previous are computed here, and the CLI — not the model —
+ * adds up the weighted total and picks the winner. A model scoring its own
+ * concepts on originality is grading its own homework.
+ *
+ * The chosen concept then stops being a suggestion. Every later stage reads it
+ * as a constraint, which is what stops an implementation drifting back into
+ * another typography video.
+ */
+
+import path from "node:path";
+import { rankConcepts, WEIGHTS } from "../lib/score/concept.mjs";
+import { Memory, resolveProject } from "../lib/state.mjs";
+import { acceptTaskAnswer, emitTaskSpec } from "../lib/taskspec.mjs";
+import { EXIT, gateError, report, say } from "../lib/util.mjs";
+
+const TASK = "concept_scores";
+
+export async function run({ flags, args }) {
+  const project = resolveProject(flags);
+  project.load();
+  if (flags.accept) return accept(project);
+  if (args?.[0]) return lockByName(project, args[0]);
+  return emit(project);
+}
+
+function emit(project) {
+  const { concepts } = project.read("concepts.json");
+  const positioning = project.read("positioning.json");
+
+  const { specPath } = emitTaskSpec({
+    project,
+    name: TASK,
+    title: "Score the concepts",
+    objective:
+      "Rate each concept on the five things a reader of the concept can judge. You are not " +
+      "choosing the winner and you are not rating originality — those are computed. Rate " +
+      "honestly, including your own weakest concept.",
+    instructions: [
+      "product_clarity: after watching, would a viewer be able to say what the product does?",
+      "product_proof: does the concept put real, sourced evidence on screen, or does it assert?",
+      "silent_comprehension: does it still work with the sound off? Most feeds autoplay muted.",
+      "emotional_strength: does it make a viewer feel the problem, or only describe it?",
+      "platform_fit: does it suit where this will actually be watched?",
+      "Every score needs a `because` that names the specific thing in that concept. A justification that would fit any concept is not one.",
+      "Score every concept, including ones you think are weak. A set where everything is a 5 tells the CLI nothing.",
+    ],
+    schemaName: "concept_scores",
+    context: {
+      destination: positioning.audience.destination,
+      concepts: concepts.map((c) => ({
+        id: c.id,
+        name: c.name,
+        premise: c.premise,
+        central_metaphor: c.central_metaphor,
+        visual_rule: c.visual_rule,
+        emotional_arc: c.emotional_arc,
+        risk: c.risk,
+        beats: c.beats,
+      })),
+      weights: WEIGHTS,
+      note: "novelty and difference_from_previous are computed by the CLI and are not yours to rate",
+    },
+    rejects: [
+      "A `because` that could be pasted onto a different concept unchanged.",
+      "Identical scores across every concept.",
+    ],
+  });
+
+  report(
+    { ok: true, mode: "emit", spec: specPath, answer: project.answerPath(TASK) },
+    [
+      `${concepts.length} concepts to score.`,
+      "",
+      `Read ${path.relative(project.targetRoot, specPath)}, write the JSON, then:`,
+      "  brag select --accept",
+      "",
+      "Or override the scoring entirely: brag select <concept-id>",
+    ],
+  );
+  return EXIT.OK;
+}
+
+function accept(project) {
+  const { concepts } = project.read("concepts.json");
+  const answer = acceptTaskAnswer({ project, name: TASK, schemaName: "concept_scores" });
+
+  const scored = new Set(answer.scores.map((s) => s.concept_id));
+  const missing = concepts.filter((c) => !scored.has(c.id)).map((c) => c.id);
+  if (missing.length) {
+    throw gateError(`these concepts were not scored: ${missing.join(", ")}`);
+  }
+
+  const { ranked, winner } = rankConcepts({
+    concepts,
+    scores: answer.scores,
+    history: new Memory().recentFingerprints(10),
+  });
+
+  const flat = ranked.map((r) => r.total);
+  if (flat.length > 1 && Math.max(...flat) - Math.min(...flat) < 1) {
+    say(
+      "note: the scores barely separate these concepts, which usually means they are " +
+        "closer to each other than the set intended.",
+    );
+  }
+
+  return lock(project, winner, ranked);
+}
+
+/** Skip scoring and lock a named concept — the user's call always wins. */
+function lockByName(project, id) {
+  const { concepts } = project.read("concepts.json");
+  const concept = concepts.find((c) => c.id === id);
+  if (!concept) {
+    throw gateError(`no concept "${id}". Have: ${concepts.map((c) => c.id).join(", ")}`);
+  }
+  return lock(
+    project,
+    { concept, rated: {}, computed: {}, total: 0, justifications: {} },
+    [],
+    { chosenByHand: true },
+  );
+}
+
+function lock(project, winner, ranked, { chosenByHand = false } = {}) {
+  const c = winner.concept;
+  const locked = {
+    schema: "brag.selected_concept/1",
+    id: c.id,
+    name: c.name,
+    premise: c.premise,
+    central_metaphor: c.central_metaphor,
+    visual_rule: c.visual_rule,
+    emotional_arc: c.emotional_arc,
+    forbidden_motifs: c.forbidden_motifs,
+    suggested_world: c.suggested_world,
+    beats: c.beats,
+    why_this_product: c.why_this_product,
+    risk: c.risk,
+    selection: {
+      total: winner.total,
+      rated: winner.rated,
+      computed: winner.computed,
+      runners_up: ranked
+        .slice(1)
+        .map((r) => ({ id: r.concept.id, total: r.total, worth_grafting: r.concept.central_metaphor })),
+      selected_at: new Date().toISOString(),
+    },
+  };
+  project.write("selected_concept.json", locked);
+
+  report(
+    { ok: true, selected: c.id, total: winner.total, ranked: ranked.map((r) => ({ id: r.concept.id, total: r.total })) },
+    [
+      chosenByHand ? `Locked "${c.name}" by hand.` : `Locked "${c.name}" — ${winner.total} points.`,
+      `  metaphor: ${c.central_metaphor}`,
+      `  rule: ${c.visual_rule}`,
+      c.suggested_world ? `  world: ${c.suggested_world}` : "",
+      ...(ranked.length > 1
+        ? ["", "Runners-up, worth grafting from:", ...ranked.slice(1).map((r) => `  ${r.total.toFixed(1).padStart(5)}  ${r.concept.id} — ${r.concept.central_metaphor}`)]
+        : []),
+      "",
+      "This is now a constraint, not a suggestion.",
+      "Next: brag direct --emit",
+    ].filter(Boolean),
+  );
+  return EXIT.OK;
+}

--- a/cli/commands/status.mjs
+++ b/cli/commands/status.mjs
@@ -1,0 +1,41 @@
+/**
+ * brag status — what is done, what is next.
+ *
+ * Stage completion is derived from artifacts on disk, so this is always true
+ * even if a previous run crashed halfway.
+ */
+
+import path from "node:path";
+import { resolveProject } from "../lib/state.mjs";
+import { EXIT, report } from "../lib/util.mjs";
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  const info = project.load();
+  const stages = project.stageStatus();
+  const next = project.nextStage();
+
+  const lines = [
+    `${info.name} — brag ${info.brag_version}`,
+    "",
+    ...stages.map(
+      (s) => `  ${s.done ? "done" : "    "}  ${s.id.padEnd(11)} ${s.done ? s.path : `→ brag ${s.command} --emit`}`,
+    ),
+    "",
+    next
+      ? `Next: brag ${next.command} --emit   (produces ${next.artifact})`
+      : "Every stage has an artifact. Run `brag deliver` again to re-cut, or `brag variant <format>`.",
+  ];
+
+  report(
+    {
+      ok: true,
+      name: info.name,
+      dir: path.relative(process.cwd(), project.dir),
+      stages: stages.map(({ id, command, artifact, done }) => ({ id, command, artifact, done })),
+      next: next?.id ?? null,
+    },
+    lines,
+  );
+  return EXIT.OK;
+}

--- a/cli/commands/storyboard.mjs
+++ b/cli/commands/storyboard.mjs
@@ -1,0 +1,148 @@
+/**
+ * brag storyboard — build the scene graph.
+ *
+ * This is where the locked concept becomes a connected film. Scenes carry
+ * purpose, the proof they must show, what a viewer has to read, and continuity
+ * edges; seams carry vectors and carriers. A flat list of slides is what this
+ * format exists to prevent.
+ */
+
+import path from "node:path";
+import { blueprintIds, ruleIds, transitionNames } from "../lib/hyperframes.mjs";
+import { minimumDuration } from "../lib/solve/timing.mjs";
+import { resolveProject } from "../lib/state.mjs";
+import { acceptTaskAnswer, emitTaskSpec } from "../lib/taskspec.mjs";
+import { getWorld, worldsFor } from "../lib/worlds.mjs";
+import { EXIT, gateError, report } from "../lib/util.mjs";
+
+const TASK = "scene_graph";
+
+export async function run({ flags }) {
+  const project = resolveProject(flags);
+  project.load();
+  return flags.accept ? accept(project) : emit(project, flags);
+}
+
+async function emit(project, flags) {
+  const model = project.read("product_model.json");
+  const positioning = project.read("positioning.json");
+  const concept = project.read("selected_concept.json", { optional: true });
+
+  const world = getWorld(
+    flags.world ?? concept?.suggested_world ?? worldsFor(model.surface_type)[0].id,
+  );
+  const rules = [...(await ruleIds())].sort();
+
+  const { specPath } = emitTaskSpec({
+    project,
+    name: TASK,
+    title: "Build the scene graph",
+    objective:
+      "Turn the locked concept into a connected film: scenes with a purpose, the proof each " +
+      "must show, what has to be readable, and how every cut travels. Not a list of slides — " +
+      "the edges between scenes are the part that makes it a film.",
+    instructions: [
+      "Every scene needs a `purpose` that says why it exists. A scene that cannot state one should be cut.",
+      "Put the strongest evidence on screen: `required_proof` names proof ids from the product model, and the fidelity check will look for them in the rendered frame.",
+      "`reading` lists what a viewer must actually read. Keep it short — a scene lasts as long as its copy needs plus a beat, and the solver will trim anything longer.",
+      "Give scenes `continuity_from` / `continuity_to` so the film has edges, and one `seam` per cut with an axis and direction.",
+      "Vary how the cuts travel. A film whose every seam is the same move reads as a slideshow, and the sameness gate will refuse it.",
+      "Where an object persists across a cut, name it as the seam's `carrier` — but only if it is genuinely the same size on both sides, or the seam gate will call it drift.",
+      "Cite motion by id from the installed pack. Inventing a name fails at compose.",
+      "Mark the one deliberately quiet scene with `quiet: true`.",
+      "Obey the locked concept's `visual_rule`, and never describe a scene using one of its `forbidden_motifs`.",
+    ],
+    schemaName: "scene_graph",
+    context: {
+      concept: concept
+        ? {
+            id: concept.id,
+            central_metaphor: concept.central_metaphor,
+            visual_rule: concept.visual_rule,
+            emotional_arc: concept.emotional_arc,
+            forbidden_motifs: concept.forbidden_motifs,
+            beats: concept.beats,
+          }
+        : null,
+      world: {
+        id: world.id,
+        summary: world.summary,
+        camera_model: world.camera_model,
+        depth_levels: world.depth_levels,
+        transition_families: world.transition_families,
+        layouts: world.layouts.map((l) => l.id),
+      },
+      angle: positioning.angle,
+      claims: positioning.claims,
+      proofs: model.proof.map((p) => ({ id: p.id, claim: p.claim, strength: p.strength })),
+      verbatim_copy: model.verbatim_copy,
+      visual_surfaces: model.visual_surfaces,
+      available_motion_rules: rules,
+      available_blueprints: [...blueprintIds()].sort(),
+      available_transitions: [...transitionNames()].sort(),
+      format: { width: 1920, height: 1080, fps: 30 },
+    },
+    rejects: [
+      "A scene with no `purpose`.",
+      "A `required_proof` id that is not in the product model.",
+      "A motion rule or blueprint id that is not in the lists above.",
+      "Every seam using the same technique.",
+      "A scene described using one of the concept's forbidden motifs.",
+    ],
+  });
+
+  report(
+    { ok: true, mode: "emit", spec: specPath, world: world.id },
+    [
+      `World: ${world.id} — ${world.layouts.length} layouts, cuts may be ${world.transition_families.join(" / ")}.`,
+      `${rules.length} motion rules available to cite.`,
+      "",
+      `Read ${path.relative(project.targetRoot, specPath)}, write the JSON, then:`,
+      "  brag storyboard --accept",
+    ],
+  );
+  return EXIT.OK;
+}
+
+function accept(project) {
+  const graph = acceptTaskAnswer({ project, name: TASK, schemaName: "scene_graph" });
+  const model = project.read("product_model.json");
+
+  /* Cheap structural checks here; compose repeats the full set against the
+     installed motion vocabulary once a world is chosen. */
+  const problems = [];
+  const proofIds = new Set(model.proof.map((p) => p.id));
+  for (const scene of graph.scenes) {
+    for (const ref of scene.required_proof ?? []) {
+      if (!proofIds.has(ref)) problems.push(`scene "${scene.id}" requires unknown proof "${ref}"`);
+    }
+    const min = minimumDuration(scene);
+    if (scene.duration < min - 0.01) {
+      problems.push(
+        `scene "${scene.id}" is ${scene.duration}s but needs ${min}s to show its copy`,
+      );
+    }
+  }
+  if ((graph.seams ?? []).length < graph.scenes.length - 1) {
+    problems.push(
+      `${graph.scenes.length} scenes but only ${(graph.seams ?? []).length} seams — every cut needs one`,
+    );
+  }
+
+  if (problems.length) {
+    throw gateError("the scene graph does not hold together:\n" + problems.map((p) => `  - ${p}`).join("\n"));
+  }
+
+  project.write("scene_graph.json", graph);
+
+  report(
+    { ok: true, mode: "accept", scenes: graph.scenes.length, seams: (graph.seams ?? []).length },
+    [
+      `Recorded scene_graph.json — ${graph.scenes.length} scenes, ${(graph.seams ?? []).length} seams.`,
+      ...graph.scenes.map((s) => `  ${s.id.padEnd(16)} ${s.duration}s  ${s.purpose.slice(0, 60)}`),
+      "",
+      "Next: brag compose",
+    ],
+  );
+  return EXIT.OK;
+}

--- a/cli/commands/variant.mjs
+++ b/cli/commands/variant.mjs
@@ -1,0 +1,121 @@
+/**
+ * brag variant — recompose the same story for another shape.
+ *
+ * A variant is a recompile, not a copied directory. One HyperFrames project is
+ * one canvas size, but the scene graph sits upstream of any project, so a
+ * different format re-solves layout and timing from the same source rather
+ * than re-cutting a finished film.
+ *
+ * What changes is framing and density, never the argument: the scenes, their
+ * order, their proof requirements and their reading floors are the same in
+ * every shape.
+ */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { minimumDuration } from "../lib/solve/timing.mjs";
+import { resolveProject } from "../lib/state.mjs";
+import { EXIT, gateError, report, say, writeJson } from "../lib/util.mjs";
+
+/** Shapes worth having, and what each is for. */
+export const FORMATS = {
+  landscape: { width: 1920, height: 1080, fps: 30, why: "the default: embeds, README, a link in a thread" },
+  vertical: { width: 1080, height: 1920, fps: 30, why: "a feed that autoplays muted and fills the screen" },
+  square: { width: 1080, height: 1080, fps: 30, why: "timelines that crop anything taller" },
+};
+
+export async function run({ flags, args }) {
+  const project = resolveProject(flags);
+  project.load();
+
+  const name = args?.[0];
+  if (!name || !FORMATS[name]) {
+    throw gateError(
+      `name a format: ${Object.keys(FORMATS).join(", ")}.\n` +
+        Object.entries(FORMATS)
+          .map(([k, f]) => `  ${k.padEnd(10)} ${f.width}x${f.height} — ${f.why}`)
+          .join("\n"),
+    );
+  }
+
+  const format = FORMATS[name];
+  const graph = project.read("scene_graph.json");
+  const recomposed = recompose(graph, { format, name });
+
+  const dropped = graph.scenes.length - recomposed.scenes.length;
+  if (dropped) {
+    say(`Dropped ${dropped} scene(s) that could not earn their place in this shape.`);
+  }
+
+  /* Written where compose reads it, then compose does the rest — one compiler,
+     so a variant cannot drift from the shape it is a variant of. */
+  writeJson(project.path("tasks", "scene_graph.json"), recomposed);
+  writeJson(project.path("scene_graph.json"), recomposed);
+
+  const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "brag.mjs");
+  const res = spawnSync(
+    process.execPath,
+    [cli, "compose", "-C", project.targetRoot, "--variant", name, ...(flags["skip-gates"] ? ["--skip-gates"] : [])],
+    { stdio: "inherit" },
+  );
+  if (res.status !== 0) return res.status ?? EXIT.GATE;
+
+  report(
+    { ok: true, variant: name, format, scenes: recomposed.scenes.length },
+    ["", `Composed "${name}" — ${format.width}x${format.height}, ${recomposed.scenes.length} scenes.`, "", `Next: brag deliver --variant ${name}`],
+  );
+  return EXIT.OK;
+}
+
+/* ------------------------------------------------------------------ solve */
+
+/**
+ * Re-solve the graph for a shape.
+ *
+ * Objects carry their own framing intent, so the solve is a matter of reading
+ * it: an object marked `omit` in this orientation leaves, and a scene left
+ * with nothing that matters goes with it — unless it is carrying required
+ * proof, which no reshape is allowed to drop.
+ */
+export function recompose(graph, { format, name }) {
+  const portrait = format.height > format.width;
+  const orientation = portrait ? "portrait" : "landscape";
+
+  const objects = (graph.objects ?? []).filter(
+    (o) => (o.layout?.[orientation] ?? "primary") !== "omit",
+  );
+  const kept = new Set(objects.map((o) => o.id));
+
+  const scenes = graph.scenes
+    .map((scene) => ({
+      ...scene,
+      objects: (scene.objects ?? []).filter((o) => kept.has(o.id)),
+    }))
+    .filter((scene) => {
+      /* Proof outranks framing. A shape that cannot show the evidence is the
+         wrong shape, not a reason to quietly ship the claim without it. */
+      if ((scene.required_proof ?? []).length) return true;
+      return scene.objects.length > 0 || (scene.reading ?? []).length > 0;
+    })
+    .map((scene) => ({
+      /* A narrower frame carries fewer words per line, so copy needs longer,
+         not shorter. The floor moves with the shape. */
+      ...scene,
+      duration: Math.max(scene.duration, minimumDuration(scene) * (portrait ? 1.1 : 1)),
+    }));
+
+  const ids = new Set(scenes.map((s) => s.id));
+  const seams = (graph.seams ?? []).filter((s) => ids.has(s.from) && ids.has(s.to));
+
+  return {
+    ...graph,
+    /* `why` is documentation for the operator choosing a shape, not part of
+       the compiled format. */
+    format: { width: format.width, height: format.height, fps: format.fps, name },
+    objects,
+    scenes,
+    seams,
+    audio: { ...(graph.audio ?? {}), silent_comprehension: portrait ? true : graph.audio?.silent_comprehension },
+  };
+}

--- a/cli/commands/watch.mjs
+++ b/cli/commands/watch.mjs
@@ -1,0 +1,121 @@
+/**
+ * brag watch — turn a render into something a reviewer can actually look at.
+ *
+ * No skill exists for watching a video, so this builds the artifact one would
+ * need: stills at the moments the video was designed around, a contact sheet,
+ * and a measurement per frame. A reviewer — human or agent — reads those.
+ *
+ * `--deep` would additionally send the file for scene-by-scene analysis, which
+ * is opt-in on purpose: it uploads the render to a third party, takes minutes,
+ * and is the wrong default for a loop that runs on every revision.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { buildBundle } from "../lib/watch/bundle.mjs";
+import { resolveProject } from "../lib/state.mjs";
+import { EXIT, ensureDir, envError, gateError, report, say, writeJson } from "../lib/util.mjs";
+
+export async function run({ flags, args }) {
+  const project = resolveProject(flags);
+  project.load();
+  const graph = project.read("scene_graph.json");
+
+  const video = resolveVideo({ project, flags, args });
+  const duration = probeDuration(video);
+
+  const variant = path.basename(video, path.extname(video));
+  const outDir = ensureDir(project.path("reviews", variant));
+
+  say(`Watching ${path.relative(project.targetRoot, video)} (${duration}s)…`);
+
+  const { frames, contactSheet } = buildBundle({ video, graph, duration, outDir });
+
+  const bundle = {
+    schema: "brag.watch_bundle/1",
+    video: path.relative(project.dir, video).split(path.sep).join("/"),
+    duration,
+    frame_count: frames.length,
+    contact_sheet: contactSheet
+      ? path.relative(project.dir, contactSheet).split(path.sep).join("/")
+      : null,
+    audio: probeAudio(video),
+    frames,
+    watched_at: new Date().toISOString(),
+  };
+  writeJson(path.join(outDir, "watch.json"), bundle);
+
+  if (flags.deep) {
+    say(
+      "--deep would upload this render for third-party scene analysis; that path is " +
+        "declared but not wired, so nothing left the machine.",
+    );
+  }
+
+  report(
+    { ok: true, ...bundle, frames: frames.length },
+    [
+      `Watched ${frames.length} frames across ${duration}s.`,
+      contactSheet ? `  ${path.relative(project.targetRoot, contactSheet)}` : "  (no contact sheet)",
+      `  ${path.relative(project.targetRoot, path.join(outDir, "watch.json"))}`,
+      "",
+      "Next: brag review",
+    ],
+  );
+  return EXIT.OK;
+}
+
+/* ------------------------------------------------------------------ helpers */
+
+export function resolveVideo({ project, flags, args = [], variant = null }) {
+  /* A named variant means that variant's delivered file, not whatever the
+     manifest happens to point at. */
+  if (variant) {
+    const named = project.path("delivery", `${variant}.mp4`);
+    if (fs.existsSync(named)) return named;
+  }
+  const explicit = args[0] ?? flags.video;
+  if (explicit) {
+    const p = path.isAbsolute(explicit) ? explicit : path.join(project.targetRoot, explicit);
+    if (!fs.existsSync(p)) throw gateError(`no such video: ${p}`);
+    return p;
+  }
+
+  const manifest = project.read("delivery/manifest.json", { optional: true });
+  if (manifest?.video) {
+    const p = path.join(project.dir, manifest.video);
+    if (fs.existsSync(p)) return p;
+  }
+
+  const renders = project.path("renders");
+  const candidates = fs.existsSync(renders)
+    ? fs.readdirSync(renders).filter((f) => f.endsWith(".mp4")).sort()
+    : [];
+  if (!candidates.length) {
+    throw gateError("no render to watch. Run `brag deliver` first, or pass a path.");
+  }
+  return path.join(renders, candidates[0]);
+}
+
+export function probeDuration(video) {
+  const res = spawnSync(
+    "ffprobe",
+    ["-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", video],
+    { encoding: "utf8", timeout: 60_000 },
+  );
+  if (res.error?.code === "ENOENT") throw envError("ffprobe is not on PATH");
+  const d = Number(String(res.stdout).trim());
+  if (!Number.isFinite(d) || d <= 0) throw gateError(`could not read a duration from ${video}`);
+  return Number(d.toFixed(3));
+}
+
+function probeAudio(video) {
+  const res = spawnSync(
+    "ffprobe",
+    ["-v", "error", "-select_streams", "a", "-show_entries", "stream=codec_name", "-of", "csv=p=0", video],
+    { encoding: "utf8", timeout: 60_000 },
+  );
+  const codec = String(res.stdout).trim().split(/\r?\n/)[0];
+  return codec ? { present: true, codec } : { present: false, codec: null };
+}

--- a/cli/frame-packets.mjs
+++ b/cli/frame-packets.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+// Thin wrapper over the shared packet builder in hyperframes-core — this file
+// only pins the paths specific to brag. The logic (frame splitting, rule
+// citation, packet bounds, `_role.md` assembly) has one owner:
+// hyperframes-core/scripts/lib/frame-packets-core.mjs
+//
+// The paths are resolved at runtime rather than vendored, because the skills
+// are a moving upstream and a copied rule index goes stale silently.
+
+import { resolve } from "node:path";
+import { skillsRoot } from "./lib/hyperframes.mjs";
+
+const PLUGIN_ROOT = resolve(import.meta.dirname, "..");
+
+function config() {
+  const root = skillsRoot();
+  return {
+    animationDir: resolve(root, "hyperframes-animation"),
+    corePath: resolve(root, "hyperframes-core", "references", "frame-worker-core.md"),
+    deltaPath: resolve(PLUGIN_ROOT, "skills", "brag", "sub-agents", "frame-worker.md"),
+  };
+}
+
+async function core() {
+  const root = skillsRoot();
+  const url = new URL(
+    `file:///${resolve(root, "hyperframes-core", "scripts", "lib", "frame-packets-core.mjs").replace(/\\/g, "/")}`,
+  );
+  return import(url.href);
+}
+
+export async function buildRolePayload({ outDir }) {
+  return (await core()).buildRolePayload({ ...config(), outDir });
+}
+
+export async function buildFramePackets(options) {
+  return (await core()).buildFramePackets({ ...config(), ...options });
+}

--- a/cli/lib/capture/redact.mjs
+++ b/cli/lib/capture/redact.mjs
@@ -1,0 +1,68 @@
+/**
+ * Redaction, applied before anything touches disk.
+ *
+ * A capture records whatever the product printed, and products print tokens,
+ * home directories and hostnames. Redacting at write time rather than at
+ * render time matters: the raw stream is kept as ground truth, so a secret
+ * that reaches the artifact is a secret on disk in the user's repo.
+ *
+ * The patterns are deliberately broad. A false positive costs a blanked string
+ * in a demo; a false negative costs a leaked credential in a published video.
+ */
+
+const HOME = (process.env.HOME ?? process.env.USERPROFILE ?? "").replace(/\\/g, "/");
+
+const PATTERNS = [
+  /* Provider-shaped keys first, because they are unambiguous. */
+  { kind: "github_token", re: /\bgh[pousr]_[A-Za-z0-9]{16,}\b/g },
+  { kind: "openai_key", re: /\bsk-[A-Za-z0-9_-]{20,}\b/g },
+  { kind: "anthropic_key", re: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g },
+  { kind: "aws_key", re: /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g },
+  { kind: "slack_token", re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g },
+  { kind: "google_key", re: /\bAIza[A-Za-z0-9_-]{30,}\b/g },
+  { kind: "private_key", re: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g },
+  { kind: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g },
+
+  /* Named secrets in assignments or headers. */
+  { kind: "assigned_secret", re: /\b((?:api[_-]?key|secret|token|password|passwd|pwd|auth)\s*[:=]\s*)(["']?)([^\s"',;]{6,})\2/gi, replace: (m, p1, q) => `${p1}${q}[redacted]${q}` },
+  { kind: "bearer", re: /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{12,}/g, replace: (m, scheme) => `${scheme} [redacted]` },
+
+  /* Connection strings carry credentials in the authority. */
+  { kind: "connection_string", re: /\b([a-z][a-z0-9+.-]*:\/\/)([^:@\s/]+):([^@\s/]+)@/gi, replace: (m, proto, user) => `${proto}${user}:[redacted]@` },
+
+  { kind: "email", re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g },
+];
+
+/**
+ * @param {string} text
+ * @returns {{text: string, hits: [string, number][]}}
+ */
+export function redact(text) {
+  if (!text) return { text: "", hits: [] };
+  const counts = new Map();
+  let out = text;
+
+  for (const { kind, re, replace } of PATTERNS) {
+    out = out.replace(re, (...args) => {
+      counts.set(kind, (counts.get(kind) ?? 0) + 1);
+      return replace ? replace(...args) : "[redacted]";
+    });
+  }
+
+  /* The operator's home directory is not a secret, but it is their name on
+     screen in a published video. Replaced with the conventional shorthand
+     rather than blanked, so the path still reads as a path. */
+  if (HOME.length > 3) {
+    const escaped = HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const homeRe = new RegExp(`${escaped}|${escaped.replace(/\//g, "\\\\\\\\")}`, "gi");
+    out = out.replace(homeRe, () => {
+      counts.set("home_path", (counts.get("home_path") ?? 0) + 1);
+      return "~";
+    });
+  }
+
+  return { text: out, hits: [...counts] };
+}
+
+/** Would this string survive redaction unchanged? */
+export const isClean = (text) => redact(text).text === text;

--- a/cli/lib/capture/terminal.mjs
+++ b/cli/lib/capture/terminal.mjs
@@ -1,0 +1,348 @@
+/**
+ * Terminal capture, without a screen recorder.
+ *
+ * No recorder exists on this machine — no asciinema, agg, vhs or termtosvg —
+ * and a screencast would be the wrong artifact anyway. What gets captured is
+ * the byte stream, which is strictly better for this pipeline: it is
+ * deterministic to replay, diffable, styleable in the film's own palette,
+ * resolution-independent, and re-timable by the timing solver. A .cast or an
+ * .mp4 gives none of that.
+ *
+ * The stream is replayed through a real terminal emulator rather than a
+ * hand-rolled ANSI parser. Carriage returns, cursor moves and line erasure are
+ * exactly what a spinner or a progress bar is made of — the moments most worth
+ * showing in a CLI video — and a regex would turn them into garbage.
+ *
+ * Typed input is synthesized at a readable cadence, because real keystroke
+ * timing is noise. Every *output* byte is real, and provenance records that
+ * distinction so a video can never imply the typing was live.
+ */
+
+import { spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+import { redact } from "./redact.mjs";
+import { gateError } from "../util.mjs";
+
+/** A screen must survive this long to count as something a viewer saw. */
+const SETTLE_MS = 80;
+
+export const DEFAULT_GEOMETRY = { cols: 100, rows: 30 };
+
+/* ------------------------------------------------------------------ running */
+
+/**
+ * Run one command and record its output as timestamped chunks.
+ *
+ * Without a PTY most tools disable colour and progress rendering, so colour is
+ * forced and the absence of a real TTY is recorded rather than hidden. A
+ * capture that quietly lost its spinners would be a lie by omission.
+ */
+/**
+ * Quote one argument for cmd.exe.
+ *
+ * Spawning with `shell: true` is not an option here: Node concatenates the
+ * arguments without escaping them, so the command that runs stops being the
+ * command that was declared — the exact failure a truth-capturing stage cannot
+ * have. Windows still needs a shell to reach `.cmd` shims like npm, so the
+ * command line is built explicitly and handed over verbatim.
+ */
+function quoteForCmd(arg) {
+  if (arg === "") return '""';
+  if (!/[\s"^&|<>()%!]/.test(arg)) return arg;
+  return `"${String(arg).replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1")}"`;
+}
+
+function spawnArgs(argv) {
+  if (process.platform !== "win32") {
+    return { file: argv[0], args: argv.slice(1), options: {} };
+  }
+  const line = argv.map(quoteForCmd).join(" ");
+  return {
+    file: process.env.ComSpec || "cmd.exe",
+    args: ["/d", "/s", "/c", line],
+    options: { windowsVerbatimArguments: true },
+  };
+}
+
+export function runCommand({
+  argv,
+  cwd,
+  env = {},
+  geometry = DEFAULT_GEOMETRY,
+  timeoutMs = 120_000,
+}) {
+  return new Promise((resolve, reject) => {
+    const started = process.hrtime.bigint();
+    const raw = [];
+    const at = () => Number((process.hrtime.bigint() - started) / 1_000_000n);
+
+    const { file, args, options } = spawnArgs(argv);
+    const child = spawn(file, args, {
+      ...options,
+      cwd,
+      env: {
+        ...process.env,
+        ...env,
+        FORCE_COLOR: "3",
+        CLICOLOR_FORCE: "1",
+        TERM: "xterm-256color",
+        COLUMNS: String(geometry.cols),
+        LINES: String(geometry.rows),
+        /* Keep the capture reproducible and free of the operator's identity. */
+        NO_UPDATE_NOTIFIER: "1",
+        CI: "",
+      },
+      windowsHide: true,
+    });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(gateError(`\`${argv.join(" ")}\` did not finish within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stdout?.on("data", (d) => raw.push({ t_ms: at(), stream: "out", data: d }));
+    child.stderr?.on("data", (d) => raw.push({ t_ms: at(), stream: "err", data: d }));
+
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      reject(gateError(`could not run \`${argv.join(" ")}\`: ${e.message}`));
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        exit_code: code ?? -1,
+        duration_ms: at(),
+        raw,
+        pty: false,
+      });
+    });
+  });
+}
+
+/* ------------------------------------------------------------------ emulation */
+
+let TerminalCtor = null;
+
+async function terminal(geometry) {
+  if (!TerminalCtor) {
+    try {
+      const mod = await import("@xterm/headless");
+      TerminalCtor = mod.default?.Terminal ?? mod.Terminal;
+    } catch {
+      throw gateError(
+        "terminal capture needs a terminal emulator.\n" +
+          "Run `npm install` in the brag repo, then try again.\n" +
+          "Hand-parsing ANSI is not an option here: carriage returns and line erasure are " +
+          "what spinners and progress bars are made of, and getting them wrong produces " +
+          "garbage rather than a visible failure.",
+      );
+    }
+  }
+  return new TerminalCtor({
+    cols: geometry.cols,
+    rows: geometry.rows,
+    allowProposedApi: true,
+    scrollback: 0,
+    /* A real tty applies ONLCR, turning a bare line feed into a carriage
+       return plus line feed. Captured without a pty the stream has bare line
+       feeds, so without this every line after the first starts at whatever
+       column the last one ended on — a staircase no user has ever seen. */
+    convertEol: true,
+  });
+}
+
+const writeChunk = (term, data) =>
+  new Promise((resolve) => term.write(data, () => resolve()));
+
+/** Group a row's cells into runs of identical styling. */
+function rowRuns(line, cols) {
+  const runs = [];
+  let current = null;
+
+  for (let x = 0; x < cols; x++) {
+    const cell = line.getCell(x);
+    if (!cell) break;
+    const chars = cell.getChars() || " ";
+    const style = {
+      fg: cell.isFgDefault() ? null : cell.getFgColor(),
+      bg: cell.isBgDefault() ? null : cell.getBgColor(),
+      bold: Boolean(cell.isBold()),
+      dim: Boolean(cell.isDim()),
+      italic: Boolean(cell.isItalic()),
+      underline: Boolean(cell.isUnderline()),
+      inverse: Boolean(cell.isInverse()),
+    };
+    const key = JSON.stringify(style);
+
+    if (current && current.key === key) {
+      current.text += chars;
+    } else {
+      if (current) runs.push(current);
+      current = { col: x, text: chars, key, ...style };
+    }
+  }
+  if (current) runs.push(current);
+
+  /* Trailing blanks are padding, not content, so the row is trimmed from the
+     right — but only at the row's end. Trimming every run would eat the space
+     between a word and the coloured word after it, which is a different style
+     and therefore a different run: "done OK" would come back as "doneOK". */
+  const trimmed = runs.map(({ key, ...run }) => run);
+  while (trimmed.length && !trimmed.at(-1).text.trim()) trimmed.pop();
+  if (trimmed.length) {
+    const last = trimmed.at(-1);
+    last.text = last.text.replace(/\s+$/, "");
+  }
+  return trimmed;
+}
+
+function snapshot(term, geometry) {
+  const buffer = term.buffer.active;
+  const grid = [];
+  for (let y = 0; y < geometry.rows; y++) {
+    const line = buffer.getLine(y);
+    if (!line) continue;
+    const runs = rowRuns(line, geometry.cols);
+    if (runs.length) grid.push({ row: y, runs });
+  }
+  return {
+    grid,
+    cursor: { row: buffer.cursorY, col: buffer.cursorX },
+  };
+}
+
+const digestOf = (grid) =>
+  grid.map((r) => `${r.row}:${r.runs.map((x) => `${x.col}${x.text}${x.fg ?? ""}`).join("|")}`).join("\n");
+
+/**
+ * Replay the byte stream and keep the screens that persisted.
+ *
+ * @returns {Promise<object[]>} states
+ */
+export async function emulate(raw, { geometry = DEFAULT_GEOMETRY, settleMs = SETTLE_MS } = {}) {
+  const term = await terminal(geometry);
+  const seen = [];
+
+  for (const chunk of raw) {
+    await writeChunk(term, chunk.data);
+    const shot = snapshot(term, geometry);
+    const digest = digestOf(shot.grid);
+    const last = seen.at(-1);
+    if (last && last.digest === digest) continue;
+    seen.push({ t_ms: chunk.t_ms, digest, ...shot });
+  }
+
+  /* The final screen always counts, however briefly it appeared: it is what
+     the command left behind. */
+  return seen
+    .map((state, i) => {
+      const next = seen[i + 1];
+      const hold = next ? next.t_ms - state.t_ms : settleMs;
+      return { ...state, hold_ms: hold };
+    })
+    .filter((state, i, all) => i === all.length - 1 || state.hold_ms >= settleMs);
+}
+
+/* ------------------------------------------------------------------ capture */
+
+/**
+ * Capture one declared invocation end to end.
+ *
+ * @returns {Promise<object>} a terminal_session artifact
+ */
+export async function captureTerminal({
+  id,
+  argv,
+  displayCommand,
+  cwd,
+  env,
+  geometry = DEFAULT_GEOMETRY,
+  expectExit = 0,
+  timeoutMs,
+  toolVersion,
+}) {
+  const run = await runCommand({ argv, cwd, env, geometry, timeoutMs });
+
+  if (expectExit !== null && run.exit_code !== expectExit) {
+    throw gateError(
+      `\`${argv.join(" ")}\` exited ${run.exit_code}, expected ${expectExit}. ` +
+        "A capture is product truth; recording a failed run as though it succeeded is the " +
+        "one thing this stage must never do.",
+    );
+  }
+
+  /* Redact before anything is persisted, and count what was removed.
+
+     Decoding runs through a streaming decoder rather than calling toString on
+     each chunk: a process writing UTF-8 splits multi-byte characters across
+     chunk boundaries whenever it feels like it, and decoding the halves
+     separately turns them into replacement characters. That showed up on
+     screen as a stray diamond in the middle of real captured output. */
+  const redactions = new Map();
+  const decoder = new StringDecoder("utf8");
+  const cleaned = run.raw.map((chunk, i) => {
+    const decoded =
+      decoder.write(chunk.data) + (i === run.raw.length - 1 ? decoder.end() : "");
+    const { text, hits } = redact(decoded);
+    for (const [kind, n] of hits) redactions.set(kind, (redactions.get(kind) ?? 0) + n);
+    return { ...chunk, data: Buffer.from(text, "utf8") };
+  });
+
+  const states = await emulate(cleaned, { geometry });
+
+  return {
+    schema: "brag.terminal_session/1",
+    id,
+    tool_version: toolVersion ?? null,
+    environment: {
+      cwd_rel: ".",
+      shell: process.platform === "win32" ? "cmd" : process.env.SHELL ?? "sh",
+      term: "xterm-256color",
+      cols: geometry.cols,
+      rows: geometry.rows,
+      pty: run.pty,
+      os: process.platform,
+    },
+    provenance: {
+      input: "synthesized",
+      output: "captured",
+      redactions: [...redactions].map(([kind, count]) => ({ kind, count })),
+      note: run.pty
+        ? null
+        : "captured without a pty: progress bars and spinners may be absent because the tool saw no tty",
+    },
+    invocation: {
+      argv,
+      display_command: displayCommand ?? argv.join(" "),
+      exit_code: run.exit_code,
+      duration_ms: run.duration_ms,
+    },
+    raw: cleaned.map((c) => ({
+      t_ms: c.t_ms,
+      stream: c.stream,
+      data_b64: c.data.toString("base64"),
+    })),
+    states: states.map(({ digest, ...state }) => ({ ...state, digest })),
+  };
+}
+
+/**
+ * The lines a session actually printed, in order — what the fidelity check
+ * compares a rendered frame against.
+ */
+export function sessionText(session) {
+  const last = session.states.at(-1);
+  if (!last) return [];
+  return last.grid.map((row) => {
+    /* Runs carry their column, so the row is rebuilt by position rather than
+       by joining — otherwise indentation and aligned output, which is most of
+       what a CLI prints, come back wrong. */
+    let out = "";
+    for (const run of row.runs) {
+      if (run.col > out.length) out += " ".repeat(run.col - out.length);
+      out += run.text;
+    }
+    return out.replace(/\s+$/, "");
+  });
+}

--- a/cli/lib/compile/composition.mjs
+++ b/cli/lib/compile/composition.mjs
@@ -62,7 +62,12 @@ export function projectFiles({ name, graph, pin }) {
 
 /* ------------------------------------------------------------------ index.html */
 
-export function buildIndexHtml({ model, graph, world, captures = {} }) {
+/**
+ * @param designedFrames Map of scene id → `compositions/frames/<file>` for
+ *   frames a worker has authored. A scene present here mounts its own
+ *   sub-composition; a scene absent from it falls back to the scaffold below.
+ */
+export function buildIndexHtml({ model, graph, world, captures = {}, designedFrames = new Map() }) {
   const scenes = withStarts(graph);
   const layoutFor = new Map(
     assignLayouts(world, scenes, graph.seams ?? []).map((a) => [a.scene, a.layout]),
@@ -167,6 +172,31 @@ export function buildIndexHtml({ model, graph, world, captures = {} }) {
       : null;
     if (terminal) terminals.push(terminal);
 
+    /* A designed frame wins over the generated one.
+       The generated body below is a scaffold — a flexbox, a paragraph, an
+       optional terminal — and it was never meant to be the finished film.
+       Shipping it as one produced exactly what you would expect: a world
+       declaring a push camera and five depth levels rendering as a sentence
+       on a flat page, with most of a 1080x1920 canvas empty. When a frame
+       worker has authored `compositions/frames/<n>-<id>.html`, the clip mounts
+       that instead, and HyperFrames' rule and blueprint catalogue does the
+       part it is actually good at. */
+    const designed = designedFrames.get(scene.id);
+    if (designed) {
+      /* The host IS the clip — it carries the timing and the canvas, and its
+         `data-composition-id` must match the id inside the file it mounts.
+         Wrapping it in another timed element puts two clips on one track at
+         the same instant, which the checker refuses and is right to. */
+      return (
+        `    <div id="el-${scene.id}" class="clip"` +
+        ` data-composition-id="${designed.compositionId}"` +
+        ` data-composition-src="${designed.src}"` +
+        ` data-start="${Number(scene.start.toFixed(3))}"` +
+        ` data-duration="${clipDuration}"` +
+        ` data-track-index="${i % 2}"` +
+        ` data-width="${width}" data-height="${height}"></div>`
+      );
+    }
     const body = [
       `      <div class="bg"></div>`,
       /* A split anchor distributes its children between the top and bottom
@@ -208,6 +238,9 @@ export function buildIndexHtml({ model, graph, world, captures = {} }) {
      before it can be read. */
   const tweens = scenes.flatMap((scene) => {
     const out = [];
+    /* A designed frame owns its own timeline and its own reveals. Driving its
+       reading lines from the root would fight the worker's choreography. */
+    if (designedFrames.has(scene.id)) return out;
     for (const line of scheduleReading(scene)) {
       /* The film's very first line cannot fade up from nothing. Frame 0 is
          both the thumbnail and the image a paused player parks on, so an

--- a/cli/lib/compile/composition.mjs
+++ b/cli/lib/compile/composition.mjs
@@ -125,6 +125,14 @@ export function buildIndexHtml({ model, graph, world, captures = {} }) {
               ? `        border-top: 2px solid var(--accent); padding-top: ${px(36)}px;`
               : "",
         "      }",
+        /* A split anchor with one child is not a split. Centring it would be
+           the safe answer and the wrong one: every other layout already
+           centres, so collapsing this one too makes consecutive scenes the
+           same picture with different words in them. It keeps its own band —
+           below the middle, clear of the caption zone. */
+        l.anchor === "split"
+          ? `      .lay-${l.id}.solo { justify-content: flex-end; bottom: ${Math.round(height * 0.28)}px; }`
+          : "",
       ]
         .filter(Boolean)
         .join("\n");
@@ -161,7 +169,14 @@ export function buildIndexHtml({ model, graph, world, captures = {} }) {
 
     const body = [
       `      <div class="bg"></div>`,
-      `      <div class="stage lay-${(layoutFor.get(scene.id) ?? { id: "default" }).id}" id="stage-${scene.id}">`,
+      /* A split anchor distributes its children between the top and bottom
+         edges, which is a composition only when there is more than one thing
+         to distribute. A scene holding a kicker and a single line has nothing
+         to split, so in a tall frame the line is pushed into the caption band
+         with a screen of dead space above it. Those collapse to centred. */
+      `      <div class="stage lay-${(layoutFor.get(scene.id) ?? { id: "default" }).id}${
+        (terminal ? 1 : 0) + Math.max(reading.length, 1) > 1 ? "" : " solo"
+      }" id="stage-${scene.id}">`,
       terminal ? terminal.html : "",
       scene.role ? `        <p class="kicker" id="kicker-${scene.id}">${esc(scene.role.replace(/_/g, " "))}</p>` : "",
       ...reading.map(

--- a/cli/lib/compile/composition.mjs
+++ b/cli/lib/compile/composition.mjs
@@ -1,0 +1,322 @@
+/**
+ * The composition itself: a real HyperFrames project directory.
+ *
+ * Phase 1 emits an *outline* composition — honest structure, real copy, real
+ * palette, one wrapper per scene named `#el-<scene-id>` so motion-doctrine's
+ * seam-stamp can write the seam tweens from the ledger. Frame workers replace
+ * the interiors in a later phase; the wrappers, timing and assertions do not
+ * change when they do.
+ *
+ * Project scaffolding is written here rather than shelled out to
+ * `hyperframes init` for two reasons: init refuses a non-empty directory, and
+ * a scaffold that varies between runs would break the byte-identical recompile
+ * gate that everything downstream depends on.
+ */
+
+import { TERMINAL_CSS, buildTerminalScene } from "./terminal-scene.mjs";
+import { assignLayouts } from "../worlds.mjs";
+import { scheduleReading, withStarts } from "./targets.mjs";
+
+const esc = (s) =>
+  String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+/** Trailing overlap so a seam's exit tween has somewhere to live. */
+const SEAM_TAIL = 0.4;
+
+export function projectFiles({ name, graph, pin }) {
+  return {
+    "hyperframes.json": JSON.stringify(
+      {
+        $schema: "https://hyperframes.heygen.com/schema/hyperframes.json",
+        registry: "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry",
+        paths: { blocks: "compositions", components: "compositions/components", assets: "assets" },
+        media: { autoProxy: true },
+      },
+      null,
+      2,
+    ) + "\n",
+
+    "meta.json": JSON.stringify({ id: name, name }, null, 2) + "\n",
+
+    "package.json":
+      JSON.stringify(
+        {
+          name,
+          private: true,
+          type: "module",
+          scripts: {
+            dev: `npx --yes ${pin} preview`,
+            check: `npx --yes ${pin} check`,
+            render: `npx --yes ${pin} render`,
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+  };
+}
+
+/* ------------------------------------------------------------------ index.html */
+
+export function buildIndexHtml({ model, graph, world, captures = {} }) {
+  const scenes = withStarts(graph);
+  const layoutFor = new Map(
+    assignLayouts(world, scenes, graph.seams ?? []).map((a) => [a.scene, a.layout]),
+  );
+  const { width, height, fps } = graph.format;
+  const duration = Number(
+    scenes.reduce((max, s) => Math.max(max, s.start + s.duration), 0).toFixed(3),
+  );
+
+  const palette = model.identity?.palette ?? [];
+  const pick = (role, fallback) =>
+    palette.find((p) => p.role === role || p.role.endsWith(`-${role}`))?.value ?? fallback;
+
+  const c = {
+    bg: pick("bg", "#0c1018"),
+    surface: pick("surface", "#121b28"),
+    border: pick("border", "#243144"),
+    text: pick("text", "#e7edf7"),
+    muted: pick("muted", "#94a3b8"),
+    accent: pick("accent", "#5272f2"),
+  };
+
+  const scale = Math.min(width, height) / 1080;
+  const typeScale = world?.typography?.display_scale ?? 1;
+  const px = (n) => Math.round(n * scale);
+  const tx = (n) => Math.round(n * scale * typeScale);
+
+
+  /* One CSS class per layout the chosen world declares. Scenes rotate through
+     them, so consecutive frames are composed differently — which is the thing
+     that stops a film reading as the same picture with new words in it. */
+  const ALIGN = { leading: "flex-start", center: "center", trailing: "flex-end" };
+  const ANCHOR = {
+    top: "flex-start",
+    upper: "flex-start",
+    middle: "center",
+    lower: "flex-end",
+    split: "space-between",
+  };
+  const layoutCss = world.layouts
+    .map((l) => {
+      const inset = Math.round((l.inset ?? 0.08) * Math.min(width, height));
+      /* Nothing anchors into the caption band: an "upper" block starts high,
+         a "lower" one still stops short of the bottom 17%. */
+      const top = l.anchor === "upper" ? Math.round(height * 0.14) : inset;
+      const bottom = l.anchor === "lower" ? Math.round(height * 0.2) : inset;
+      const side = Math.round(inset * 1.3);
+      return [
+        `      .lay-${l.id} {`,
+        `        top: ${top}px; bottom: ${bottom}px; left: ${side}px; right: ${side}px;`,
+        `        align-items: ${ALIGN[l.align] ?? "flex-start"};`,
+        `        justify-content: ${ANCHOR[l.anchor] ?? "center"};`,
+        `        text-align: ${l.align === "center" ? "center" : l.align === "trailing" ? "right" : "left"};`,
+        l.scale && l.scale !== 1 ? `        font-size: ${l.scale}em;` : "",
+        l.chrome === "panel"
+          ? `        background: var(--surface); border: 1px solid var(--border); border-radius: ${px(16)}px; padding: ${px(48)}px;`
+          : l.chrome === "frame"
+            ? `        border: 1px solid var(--border); padding: ${px(44)}px;`
+            : l.chrome === "rule"
+              ? `        border-top: 2px solid var(--accent); padding-top: ${px(36)}px;`
+              : "",
+        "      }",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n");
+
+  const terminals = [];
+  const clips = scenes.map((scene, i) => {
+    const isLast = i === scenes.length - 1;
+    const clipDuration = Number((scene.duration + (isLast ? 0 : SEAM_TAIL)).toFixed(3));
+    const reading = scene.reading ?? [];
+
+    /* A scene whose focal object points at a capture shows the real thing the
+       tool printed, not a description of it. */
+    /* Only the scene that makes the object focal shows the capture. An object
+       can appear in several scenes — that is what makes it an object — but
+       rendering the terminal in all of them puts the same panel on screen
+       three times and calls it continuity. */
+    const captureId = (scene.objects ?? [])
+      .filter((o) => o.focal)
+      .map((o) => graph.objects?.find((g) => g.id === o.id)?.content_ref)
+      .find((ref) => ref && captures[ref]);
+    const terminal = captureId
+      ? buildTerminalScene({
+          scene,
+          session: captures[captureId],
+          start: scene.start,
+          duration: scene.duration,
+          geometry: { width, height },
+          px,
+        })
+      : null;
+    if (terminal) terminals.push(terminal);
+
+    const body = [
+      `      <div class="bg"></div>`,
+      `      <div class="stage lay-${(layoutFor.get(scene.id) ?? { id: "default" }).id}" id="stage-${scene.id}">`,
+      terminal ? terminal.html : "",
+      scene.role ? `        <p class="kicker" id="kicker-${scene.id}">${esc(scene.role.replace(/_/g, " "))}</p>` : "",
+      ...reading.map(
+        (r, ri) =>
+          `        <p class="${ri === 0 ? "lead" : "line"}" id="read-${scene.id}-${ri}">${esc(r.text)}</p>`,
+      ),
+      reading.length === 0
+        ? `        <p class="lead" id="read-${scene.id}-0">${esc(scene.title ?? scene.purpose)}</p>`
+        : "",
+      `      </div>`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    return [
+      `    <section id="el-${scene.id}" class="clip" data-start="${Number(scene.start.toFixed(3))}" data-duration="${clipDuration}" data-track-index="${i % 2}">`,
+      body,
+      `    </section>`,
+    ].join("\n");
+  });
+
+  /* Per-scene reveals. Reading lines rise into place fast and then hold for
+     their floor — the pace comes from the cut, never from pulling copy away
+     before it can be read. */
+  const tweens = scenes.flatMap((scene) => {
+    const out = [];
+    if (scene.role) {
+      out.push(
+        `      tl.fromTo("#kicker-${scene.id}", { opacity: 0, y: ${px(14)} }, { opacity: 1, y: 0, duration: 0.32, ease: "power3.out" }, ${Number(scene.start.toFixed(2))});`,
+      );
+    }
+    for (const line of scheduleReading(scene)) {
+      out.push(
+        `      tl.fromTo("#read-${scene.id}-${line.index}", { opacity: 0, y: ${px(28)} }, { opacity: 1, y: 0, duration: 0.4, ease: "power4.out" }, ${line.enter});` +
+          `  // settled ${line.settled}s, floor ${line.floor}s${line.tight ? " (TIGHT — scene is too short for this copy)" : ""}`,
+      );
+    }
+    return out;
+  });
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=${width}, height=${height}" />
+    <title>${esc(model.name ?? "brag")}</title>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { width: ${width}px; height: ${height}px; overflow: hidden; background: ${c.bg}; }
+      :root {
+        --bg: ${c.bg};
+        --surface: ${c.surface};
+        --border: ${c.border};
+        --text: ${c.text};
+        --muted: ${c.muted};
+        --accent: ${c.accent};
+        --sans: Inter, "Segoe UI", system-ui, sans-serif;
+        --mono: "JetBrains Mono", Consolas, ui-monospace, monospace;
+      }
+      #root {
+        position: relative;
+        width: ${width}px;
+        height: ${height}px;
+        overflow: hidden;
+        background: var(--bg);
+        font-family: var(--sans);
+        color: var(--text);
+      }
+      .clip { position: absolute; inset: 0; }
+      .bg { position: absolute; inset: 0; background: var(--bg); }
+      .stage {
+        position: absolute;
+        display: flex;
+        flex-direction: column;
+        gap: ${px(24)}px;
+      }
+${layoutCss}
+      .kicker {
+        font-family: var(--mono);
+        font-size: ${px(26)}px;
+        line-height: ${px(34)}px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--accent);
+        opacity: 0;
+      }
+      .lead {
+        font-size: ${tx(64)}px;
+        line-height: ${tx(78)}px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        max-width: ${px(1500)}px;
+        opacity: 0;
+      }
+${world && terminals.length ? TERMINAL_CSS : ""}
+      .line {
+        font-size: ${tx(34)}px;
+        line-height: ${tx(46)}px;
+        color: var(--muted);
+        max-width: ${px(1400)}px;
+        opacity: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="root"
+      data-composition-id="main"
+      data-start="0"
+      data-duration="${duration}"
+      data-width="${width}"
+      data-height="${height}"
+      data-fps="${fps}"
+    >
+${clips.join("\n")}
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+
+${[...tweens, ...terminals.flatMap((t) => t.tweens)].join("\n")}
+
+      window.__timelines["main"] = tl;
+      // <seams:auto>
+      // </seams:auto>
+    </script>
+  </body>
+</html>
+`;
+}
+
+/* ------------------------------------------------------------------ frame stubs */
+
+/**
+ * Outline sub-compositions, one per scene. They are not wired into index.html
+ * yet — the storyboard's `src` points here so Studio's board can render tiles,
+ * and frame workers overwrite these files in a later phase.
+ */
+export function buildFrameStub({ scene, model, graph }) {
+  const reading = scene.reading?.length ? scene.reading : [{ text: scene.title ?? scene.purpose }];
+  return `<!-- outline frame: ${scene.id} -->
+<template>
+  <div
+    data-composition-id="${scene.id}"
+    data-start="0"
+    data-duration="${scene.duration}"
+    data-width="${graph.format.width}"
+    data-height="${graph.format.height}"
+  >
+    <section class="clip" data-start="0" data-duration="${scene.duration}" data-track-index="0">
+${reading.map((r) => `      <p>${esc(r.text)}</p>`).join("\n")}
+    </section>
+  </div>
+</template>
+`;
+}

--- a/cli/lib/compile/composition.mjs
+++ b/cli/lib/compile/composition.mjs
@@ -178,7 +178,12 @@ export function buildIndexHtml({ model, graph, world, captures = {} }) {
         (terminal ? 1 : 0) + Math.max(reading.length, 1) > 1 ? "" : " solo"
       }" id="stage-${scene.id}">`,
       terminal ? terminal.html : "",
-      scene.role ? `        <p class="kicker" id="kicker-${scene.id}">${esc(scene.role.replace(/_/g, " "))}</p>` : "",
+      /* A scene's role is how the storyboard classifies it — "Key_Feature",
+         "Social_Proof", "Brand_Outro". Printing it on the frame puts brag's
+         own filing system in front of the viewer: a blind reviewer read the
+         labels as an unfinished export, and objected that a card marked
+         SOCIAL PROOF contained no third party. It was right on both counts.
+         The role stays in the graph, where it belongs. */
       ...reading.map(
         (r, ri) =>
           `        <p class="${ri === 0 ? "lead" : "line"}" id="read-${scene.id}-${ri}">${esc(r.text)}</p>`,
@@ -203,14 +208,16 @@ export function buildIndexHtml({ model, graph, world, captures = {} }) {
      before it can be read. */
   const tweens = scenes.flatMap((scene) => {
     const out = [];
-    if (scene.role) {
-      out.push(
-        `      tl.fromTo("#kicker-${scene.id}", { opacity: 0, y: ${px(14)} }, { opacity: 1, y: 0, duration: 0.32, ease: "power3.out" }, ${Number(scene.start.toFixed(2))});`,
-      );
-    }
     for (const line of scheduleReading(scene)) {
+      /* The film's very first line cannot fade up from nothing. Frame 0 is
+         both the thumbnail and the image a paused player parks on, so an
+         entrance starting at t=0 means the video advertises itself with an
+         empty background. It arrives already legible and rises into place. */
+      const opensTheFilm = line.enter <= 0.001 && line.index === 0;
       out.push(
-        `      tl.fromTo("#read-${scene.id}-${line.index}", { opacity: 0, y: ${px(28)} }, { opacity: 1, y: 0, duration: 0.4, ease: "power4.out" }, ${line.enter});` +
+        `      tl.fromTo("#read-${scene.id}-${line.index}", ` +
+          `{ opacity: ${opensTheFilm ? 1 : 0}, y: ${px(opensTheFilm ? 12 : 28)} }, ` +
+          `{ opacity: 1, y: 0, duration: 0.4, ease: "power4.out" }, ${line.enter});` +
           `  // settled ${line.settled}s, floor ${line.floor}s${line.tight ? " (TIGHT — scene is too short for this copy)" : ""}`,
       );
     }
@@ -255,15 +262,6 @@ export function buildIndexHtml({ model, graph, world, captures = {} }) {
         gap: ${px(24)}px;
       }
 ${layoutCss}
-      .kicker {
-        font-family: var(--mono);
-        font-size: ${px(26)}px;
-        line-height: ${px(34)}px;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-        color: var(--accent);
-        opacity: 0;
-      }
       .lead {
         font-size: ${tx(64)}px;
         line-height: ${tx(78)}px;

--- a/cli/lib/compile/targets.mjs
+++ b/cli/lib/compile/targets.mjs
@@ -272,9 +272,9 @@ export function buildFrameMd({ model, graph, world = null }) {
       : ["No palette was extracted from the source, so these are neutral defaults.", ""]),
     "## Type",
     "",
-    `- Display: ${model.identity?.display_font ?? "Inter, system sans"}`,
-    `- Body: ${model.identity?.body_font ?? "Inter, system sans"}`,
-    `- Mono: ${model.identity?.mono_font ?? "JetBrains Mono, Consolas, monospace"}`,
+    `- Display: ${renderableFont(model.identity?.display_font, "Inter, system-ui, sans-serif")}`,
+    `- Body: ${renderableFont(model.identity?.body_font, "Inter, system-ui, sans-serif")}`,
+    `- Mono: ${renderableFont(model.identity?.mono_font, "JetBrains Mono, monospace")}`,
     "",
     "## Composition rules",
     "",
@@ -360,11 +360,19 @@ export function buildMotionJson({ graph }) {
       bySec: Number((scene.start + 0.5).toFixed(2)),
     });
 
+    /* The deadline, not brag's own tween schedule.
+       The requirement is that a line is on screen long enough to read: it must
+       appear by the last moment that still leaves its reading floor before the
+       scene ends. Asserting `settled` instead pinned the frame to the exact
+       entrance the scaffold happened to author, so a designed frame that
+       revealed the same line a quarter-second differently — and held it far
+       longer than the floor — failed a readability check it comfortably met. */
     scheduleReading(scene).forEach((line) => {
+      const deadline = scene.start + scene.duration - line.floor;
       assertions.push({
         kind: "appearsBy",
         selector: `#read-${scene.id}-${line.index}`,
-        bySec: line.settled,
+        bySec: Number(Math.max(line.settled, deadline).toFixed(2)),
       });
     });
   }
@@ -397,4 +405,44 @@ export function buildMotionJson({ graph }) {
   });
 
   return { duration: totalDuration(graph), assertions };
+}
+
+/**
+ * A font stack the renderer can actually supply.
+ *
+ * The product's own CSS stack is the right *intent* and the wrong thing to
+ * hand a frame worker verbatim. A browser falls back silently through a stack
+ * until something is installed; the renderer does not have the machine's fonts
+ * and fails the build on a family it cannot resolve. One project shipping
+ * `ui-monospace, SF Mono, Cascadia Mono, Menlo, monospace` put an unrenderable
+ * family into the design truth, and every frame built from it inherited the
+ * failure.
+ *
+ * So the extracted stack is filtered to families the renderer resolves, and
+ * the fallback stands in when nothing survives.
+ */
+const RENDERABLE = new Set([
+  "inter", "roboto", "roboto mono", "open sans", "lato", "montserrat", "poppins",
+  "source sans pro", "source code pro", "raleway", "oswald", "merriweather",
+  "playfair display", "ibm plex sans", "ibm plex mono", "ibm plex serif",
+  "jetbrains mono", "fira code", "fira sans", "space grotesk", "space mono",
+  "dm sans", "dm mono", "work sans", "nunito", "karla", "manrope", "rubik",
+  "system-ui", "sans-serif", "serif", "monospace", "ui-monospace", "ui-sans-serif",
+  /* Aliased to a bundled face at render time rather than rejected — the
+     checker reports these as info, so keeping them preserves the project's
+     intent without risking the build. */
+  "sf mono", "sf pro", "menlo", "consolas", "segoe ui", "helvetica", "helvetica neue", "arial",
+]);
+
+export function renderableFont(declared, fallback) {
+  if (!declared) return fallback;
+  const kept = String(declared)
+    .split(",")
+    .map((f) => f.trim().replace(/^["']|["']$/g, ""))
+    .filter((f) => f && RENDERABLE.has(f.toLowerCase()));
+  if (!kept.length) return fallback;
+  /* A generic family has to close the stack, or the renderer has nothing to
+     fall back to when the named one is missing. */
+  const generic = fallback.split(",").at(-1).trim();
+  return kept.includes(generic) ? kept.join(", ") : [...kept, generic].join(", ");
 }

--- a/cli/lib/compile/targets.mjs
+++ b/cli/lib/compile/targets.mjs
@@ -1,0 +1,400 @@
+/**
+ * Compile targets: the scene graph becomes files HyperFrames already reads.
+ *
+ * Nothing here invents a format. BRIEF.md, STORYBOARD.md, frame.md, ledger.json
+ * and the motion sidecar all belong to HyperFrames or motion-doctrine; brag's
+ * job is to fill them from one upstream source so a variant is a recompile
+ * rather than a copied directory.
+ *
+ * Everything is deterministic — no timestamps, no ordering by object identity —
+ * because "compile twice, get the same bytes" is the property that makes every
+ * later phase debuggable.
+ */
+
+const yamlString = (s) => `"${String(s).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+const secs = (n) => `${Number(n.toFixed(2))}s`;
+
+/** Scene start times, accumulated in graph order. */
+export function withStarts(graph) {
+  let t = 0;
+  return graph.scenes.map((scene) => {
+    const withStart = { ...scene, start: scene.start ?? t };
+    t = withStart.start + scene.duration;
+    return withStart;
+  });
+}
+
+export const totalDuration = (graph) =>
+  Number(withStarts(graph).reduce((max, s) => Math.max(max, s.start + s.duration), 0).toFixed(3));
+
+/* ------------------------------------------------------------------ BRIEF.md */
+
+/**
+ * The intent document. Its frontmatter uses the registry vocabulary so that a
+ * HyperFrames workflow finding this project can read it without translation.
+ */
+export function buildBrief({ model, positioning, graph, concept }) {
+  const fm = [
+    "---",
+    "workflow: brag",
+    "flow: automation",
+    "storyboard: yes",
+    `message: ${yamlString(positioning.angle)}`,
+    `audience: ${yamlString(positioning.audience.who)}`,
+    `aspect: ${graph.format.width}x${graph.format.height}`,
+    `length: ${secs(totalDuration(graph))}`,
+    `angle: ${yamlString(positioning.angle)}`,
+    positioning.audience.destination?.length
+      ? `destination: ${positioning.audience.destination.join(", ")}`
+      : null,
+    "---",
+  ].filter(Boolean);
+
+  const body = [
+    "",
+    "## Intent",
+    "",
+    `${model.name ?? "This product"} is ${model.one_line ?? model.mechanism}`,
+    "",
+    `It is for ${positioning.audience.who}. The problem: ${model.problem}`,
+    "",
+    `The video argues one thing: ${positioning.angle}`,
+    concept ? `\nThe concept is "${concept.name}" — ${concept.central_metaphor}.` : "",
+    "",
+    "## Assets",
+    "",
+    ...(model.visual_surfaces.map((s) => `- ${s.id} — ${s.description} (${s.capture ?? "synthesized"})`)),
+    "",
+    "## Notes",
+    "",
+    "Every claim in this video resolves to a proof in the product model:",
+    "",
+    ...positioning.claims.map((c) => `- ${c.text} → proof \`${c.proof_ref}\``),
+    "",
+    ...(model.forbidden_claims?.length
+      ? [
+          "Do not say, imply, or paraphrase:",
+          "",
+          ...model.forbidden_claims.map((c) => `- ${c}`),
+          "",
+        ]
+      : []),
+    ...(positioning.avoid?.length
+      ? ["Framings to avoid:", "", ...positioning.avoid.map((a) => `- ${a}`), ""]
+      : []),
+  ];
+
+  return [...fm, ...body].join("\n").replace(/\n{3,}/g, "\n\n") + "\n";
+}
+
+/* ------------------------------------------------------------------ STORYBOARD.md */
+
+/**
+ * One `## Frame N` per scene. Known keys land on the documented bullets; the
+ * whole brag payload rides under unknown keys, which the parser preserves
+ * verbatim in each frame's `extra` — which is why no parallel format is needed.
+ */
+export function buildStoryboard({ graph, positioning, model }) {
+  const scenes = withStarts(graph);
+  const arc = scenes.map((s) => s.role ?? s.id).join(" → ");
+
+  const lines = [
+    "---",
+    `format: ${graph.format.width}x${graph.format.height}`,
+    `duration: ${secs(totalDuration(graph))}`,
+    `message: ${yamlString(positioning.angle)}`,
+    `arc: ${arc}`,
+    `audience: ${yamlString(positioning.audience.who)}`,
+    "mode: autonomous",
+    "---",
+    "",
+  ];
+
+  scenes.forEach((scene, i) => {
+    const objects = (scene.objects ?? [])
+      .map((o) => (o.focal ? `${o.id}*` : o.id))
+      .join(", ");
+    const reading = scene.reading ?? [];
+
+    lines.push(`## Frame ${i + 1} — ${scene.title ?? scene.id}`);
+    lines.push("");
+    lines.push(`- scene: ${scene.purpose}`);
+    lines.push(`- duration: ${secs(scene.duration)}`);
+    lines.push(`- transition_in: ${transitionInFor(graph, scene)}`);
+    lines.push(`- status: outline`);
+    lines.push(`- src: compositions/frames/${frameFile(i, scene)}`);
+    lines.push(`- poster: ${Number((scene.duration * 0.6).toFixed(2))}s`);
+
+    /* Unknown keys — preserved under `extra`, read back by brag's own tooling. */
+    lines.push(`- brag_scene_id: ${scene.id}`);
+    if (scene.role) lines.push(`- brag_role: ${scene.role}`);
+    if (scene.required_proof?.length) lines.push(`- brag_proof: ${scene.required_proof.join(", ")}`);
+    if (objects) lines.push(`- brag_objects: ${objects}`);
+    if (scene.motif) lines.push(`- brag_motif: ${scene.motif}`);
+    if (scene.continuity_from) lines.push(`- brag_continuity_in: ${scene.continuity_from}`);
+    if (scene.continuity_to) lines.push(`- brag_continuity_out: ${scene.continuity_to}`);
+    if (scene.motion?.blueprint) lines.push(`- brag_blueprint: ${scene.motion.blueprint}`);
+    if (scene.motion?.rules?.length) lines.push(`- brag_rules: ${scene.motion.rules.join(", ")}`);
+    if (scene.quiet) lines.push(`- brag_quiet: true`);
+    lines.push(`- brag_start: ${Number(scene.start.toFixed(2))}`);
+
+    lines.push("");
+    lines.push(scene.purpose);
+    if (scene.motion?.intent) lines.push("", scene.motion.intent);
+
+    if (reading.length) {
+      lines.push("", "Must be readable here:");
+      for (const r of reading) {
+        const floor = r.min_reading_s ?? readingFloor(r.text);
+        lines.push(`- "${r.text}" — settled for at least ${secs(floor)}`);
+      }
+    }
+
+    if (scene.required_proof?.length) {
+      lines.push("", "Proof this frame must actually show:");
+      for (const id of scene.required_proof) {
+        const proof = model.proof.find((p) => p.id === id);
+        lines.push(`- ${id}: ${proof?.claim ?? "(unknown proof)"} [${proof?.strength ?? "?"}]`);
+      }
+    }
+
+    lines.push("");
+  });
+
+  return lines.join("\n");
+}
+
+export const frameFile = (i, scene) =>
+  `${String(i + 1).padStart(2, "0")}-${scene.id}.html`;
+
+function transitionInFor(graph, scene) {
+  const seam = (graph.seams ?? []).find((s) => s.to === scene.id);
+  if (!seam) return "cut";
+  return seam.technique ?? "cut";
+}
+
+/**
+ * The reading floor: about 0.3s per word, never under 0.8s for a short label.
+ * Stated once here so the storyboard, the motion sidecar and the timing solver
+ * cannot drift apart.
+ */
+export function readingFloor(text) {
+  const words = String(text).trim().split(/\s+/).filter(Boolean).length;
+  if (words === 0) return 0.8;
+  if (words <= 3) return 0.8;
+  return Math.max(1.2, Number((words * 0.3).toFixed(2)));
+}
+
+/** Gap between consecutive reading lines inside one scene. */
+const STAGGER = 0.45;
+const ENTER = 0.4;
+
+/**
+ * Schedule a scene's reading lines.
+ *
+ * Forward from the scene's start: the first line settles as soon as its
+ * entrance completes, and each subsequent line follows one stagger later. Any
+ * spare time therefore lands at the *end*, as a settled hold.
+ *
+ * Two earlier versions of this were wrong in instructive ways. Computing each
+ * line's settle time independently from the scene end silently reordered them,
+ * because a nine-word sentence has a longer floor than a four-word command and
+ * so landed first. Solving backwards from the end fixed the order but packed
+ * every line against the closing frames, leaving the opening seconds empty —
+ * which a review caught as a dead shot at the scene's own midpoint. Copy
+ * arrives promptly and then holds; slack belongs at the end, never the start.
+ *
+ * @returns {{index, text, floor, enter, settled, tight}[]}
+ */
+export function scheduleReading(scene) {
+  const lines = scene.reading?.length
+    ? scene.reading
+    : [{ text: scene.title ?? scene.purpose }];
+  const end = scene.start + scene.duration;
+  const floors = lines.map((r) => r.min_reading_s ?? readingFloor(r.text));
+
+  return lines.map((r, i) => {
+    const settled = Number((scene.start + ENTER + i * STAGGER).toFixed(2));
+    return {
+      index: i,
+      text: r.text,
+      floor: floors[i],
+      enter: Number(Math.max(scene.start, settled - ENTER).toFixed(2)),
+      settled,
+      /* Tight when the scene ends before this line has been on screen long
+         enough to read. */
+      tight: end - settled < floors[i] - 0.01,
+    };
+  });
+}
+
+/** Scenes whose copy does not fit their duration. */
+export function tightScenes(graph) {
+  return withStarts(graph)
+    .map((scene) => ({ scene, lines: scheduleReading(scene).filter((l) => l.tight) }))
+    .filter((r) => r.lines.length);
+}
+
+/* ------------------------------------------------------------------ frame.md */
+
+/**
+ * The design truth — palette, type ramp, composition rules. In Phase 3 this is
+ * generated from the chosen visual world; for now it is derived from the
+ * product's own identity, because a video that invents a palette is already
+ * off-brand.
+ */
+export function buildFrameMd({ model, graph, world = null }) {
+  const palette = model.identity?.palette ?? [];
+  const pick = (role, fallback) =>
+    palette.find((p) => p.role === role || p.role.endsWith(`-${role}`))?.value ?? fallback;
+
+  const bg = pick("bg", "#0c1018");
+  const text = pick("text", "#e7edf7");
+  const muted = pick("muted", "#94a3b8");
+  const accent = pick("accent", "#5272f2");
+
+  return [
+    `# Design truth — ${model.name ?? "the product"}`,
+    "",
+    world ? `Visual world: **${world.name}**. ${world.summary}` : "Derived from the product's own interface, not invented.",
+    "",
+    "## Palette",
+    "",
+    "| Role | Value | Source |",
+    "| --- | --- | --- |",
+    `| background | \`${bg}\` | ${sourceOf(palette, "bg")} |`,
+    `| text | \`${text}\` | ${sourceOf(palette, "text")} |`,
+    `| muted | \`${muted}\` | ${sourceOf(palette, "muted")} |`,
+    `| accent | \`${accent}\` | ${sourceOf(palette, "accent")} |`,
+    "",
+    ...(palette.length
+      ? ["Full extracted palette:", "", ...palette.map((p) => `- \`--${p.role}: ${p.value}\``), ""]
+      : ["No palette was extracted from the source, so these are neutral defaults.", ""]),
+    "## Type",
+    "",
+    `- Display: ${model.identity?.display_font ?? "Inter, system sans"}`,
+    `- Body: ${model.identity?.body_font ?? "Inter, system sans"}`,
+    `- Mono: ${model.identity?.mono_font ?? "JetBrains Mono, Consolas, monospace"}`,
+    "",
+    "## Composition rules",
+    "",
+    `- Canvas ${graph.format.width}×${graph.format.height} at ${graph.format.fps}fps.`,
+    "- Text a viewer must read is settled — entered, not yet exiting — for its full reading floor.",
+    "- Contrast is a gate, not a preference: 4.5:1 for normal text, 3:1 at 24px+.",
+    ...(model.identity?.logo_usable_on_dark === false
+      ? [
+          "- The project's logo is dark-on-transparent and disappears on this background. Use the wordmark in type instead of the mark.",
+        ]
+      : []),
+    "",
+    "## What this product looks like",
+    "",
+    ...model.visual_surfaces.map((s) => `- **${s.id}** (${s.kind}) — ${s.description}`),
+    "",
+  ].join("\n");
+}
+
+const sourceOf = (palette, role) => {
+  const hit = palette.find((p) => p.role === role || p.role.endsWith(`-${role}`));
+  return hit?.source?.file ? `\`${hit.source.file}\`` : "default";
+};
+
+/* ------------------------------------------------------------------ ledger.json */
+
+/**
+ * One row per seam, in motion-doctrine's schema. `seam-stamp` writes the actual
+ * tweens from this and `seam-gate` verifies them numerically — which is why
+ * brag describes seams as vectors and never hand-authors the motion.
+ */
+export function buildLedger({ graph }) {
+  const scenes = withStarts(graph);
+  const startOf = new Map(scenes.map((s) => [s.id, s.start]));
+
+  const axisDir = (vector) => {
+    const dir = { left: -1, up: -1, out: -1, right: 1, down: 1, in: 1 }[vector.direction] ?? -1;
+    return { axis: vector.axis, dir };
+  };
+
+  return {
+    fps: graph.format.fps,
+    seams: (graph.seams ?? []).map((seam) => {
+      const { axis, dir } = axisDir(seam.vector);
+      const row = {
+        id: `${seam.from}→${seam.to}`,
+        cut: Number((seam.at ?? startOf.get(seam.to) ?? 0).toFixed(3)),
+        technique: seam.technique ?? `cut-the-curve ${seam.vector.direction.toUpperCase()}`,
+        exit: { selector: `#el-${seam.from}`, axis, dir },
+        entry: { selector: `#el-${seam.to}`, axis, dir },
+      };
+      /* A carrier claim needs two real elements — one in each scene — whose
+         geometry matches across the cut. Naming a single selector describes
+         the incoming scene's own stage, which moves *because* of the seam, and
+         the gate rightly reads that as a jump rather than a hand-off. So the
+         ledger only asserts a carrier when the graph names both sides; the
+         plain `carrier` field stays as intent for whoever builds the frames. */
+      if (seam.carrier_out && seam.carrier_in) {
+        row.carrier = { out: `#${seam.carrier_out}`, in: `#${seam.carrier_in}` };
+      }
+      return row;
+    }),
+  };
+}
+
+/* ------------------------------------------------------------------ motion.json */
+
+/**
+ * Reading floors and proof requirements become gating assertions.
+ *
+ * This is the line that turns "intelligent timing" from a promise into an exit
+ * code: `check` seeks the same timeline the renderer uses and fails when a
+ * line a viewer must read has not appeared by the time it is supposed to.
+ */
+export function buildMotionJson({ graph }) {
+  const scenes = withStarts(graph);
+  const assertions = [];
+
+  for (const scene of scenes) {
+    assertions.push({
+      kind: "appearsBy",
+      selector: `#el-${scene.id}`,
+      bySec: Number((scene.start + 0.5).toFixed(2)),
+    });
+
+    scheduleReading(scene).forEach((line) => {
+      assertions.push({
+        kind: "appearsBy",
+        selector: `#read-${scene.id}-${line.index}`,
+        bySec: line.settled,
+      });
+    });
+  }
+
+  for (let i = 1; i < scenes.length; i++) {
+    assertions.push({ kind: "before", a: `#el-${scenes[i - 1].id}`, b: `#el-${scenes[i].id}` });
+  }
+
+  /* No `staysInFrame` anywhere.
+     It has no time window — it fails if a box *ever* leaves the canvas once
+     visible — and in a film whose scenes travel on exit, every element in
+     every non-final scene leaves by design. Asserting it on the wrapper
+     contradicts the seam; asserting it on the text contradicts the seam one
+     level down. The real question — "is the copy where a viewer can read it
+     while it is being read?" — is answered by measuring ink in the rendered
+     frames at their settled times, which is what layer 2 does.
+
+     One frozen-shot check for the whole film, not one per scene.
+     `keepsMoving` has no time window, so a per-scene assertion samples the
+     wrapper across the entire timeline — including the minutes before that
+     scene starts — and reports the wait as a frozen shot. Scoping it to the
+     root asks the real question: does the video ever stop moving?
+     The allowance is the longest legitimate settled hold, because copy held
+     still so it can be read is not a dead shot. */
+  const longestHold = Math.max(2, ...scenes.flatMap((s) => scheduleReading(s).map((l) => l.floor)));
+  assertions.push({
+    kind: "keepsMoving",
+    withinSelector: "#root",
+    maxStaticSec: Number((longestHold + 1.2).toFixed(2)),
+  });
+
+  return { duration: totalDuration(graph), assertions };
+}

--- a/cli/lib/compile/terminal-scene.mjs
+++ b/cli/lib/compile/terminal-scene.mjs
@@ -1,0 +1,182 @@
+/**
+ * Rendering a captured terminal session inside a composition.
+ *
+ * This is what makes a CLI product's video show the product. The states come
+ * from a real run — every output byte captured, replayed through a terminal
+ * emulator — so what appears on screen is what the tool actually printed,
+ * including the way a progress bar rewrote its own line.
+ *
+ * States are swapped rather than appended, because a rewrite is not an
+ * addition: `installing... 40%` becoming `installing... done` is one line
+ * changing, and appending both would be a lie about what the terminal did.
+ * The swap is a zero-duration set at a threshold, which is seek-safe in both
+ * directions — the renderer samples frames out of order and a state built by
+ * accumulation would desync.
+ */
+
+const esc = (s) =>
+  String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+/**
+ * ANSI colour index → a role in the film's palette.
+ *
+ * Terminal colours are mapped rather than reproduced. A captured green is
+ * "success" in the tool's vocabulary, and rendering it as the film's own
+ * success colour keeps the terminal part of the picture instead of a
+ * screenshot pasted into it. Anything outside the basic sixteen falls back to
+ * body text, which is the honest reading of "some colour we do not have a role
+ * for".
+ */
+const ANSI_ROLE = {
+  1: "--danger", 9: "--danger",
+  2: "--success", 10: "--success",
+  3: "--warn", 11: "--warn",
+  4: "--accent", 12: "--accent",
+  5: "--accent", 13: "--accent",
+  6: "--accent", 14: "--accent",
+  7: "--text", 15: "--text",
+  0: "--muted", 8: "--muted",
+};
+
+const colourFor = (fg) =>
+  fg === null || fg === undefined ? "var(--text)" : `var(${ANSI_ROLE[fg] ?? "--text"}, var(--text))`;
+
+/**
+ * Lay the captured states across the scene's own time.
+ *
+ * Real capture timings are wall-clock and usually far too quick to read, so
+ * they are used for *proportion* only: each state keeps its share of the
+ * scene, and no state gets less than a readable dwell. A capture whose states
+ * cannot all fit at that floor drops its briefest ones rather than flashing
+ * them, and says so.
+ */
+export function scheduleStates(states, { start, duration, minDwell = 0.5, tail = 0.34 }) {
+  const usable = Math.max(0.4, duration - tail);
+  const maxStates = Math.max(1, Math.floor(usable / minDwell));
+
+  /* Keep the longest-held states: those are the ones a person actually saw. */
+  let kept = states;
+  let dropped = 0;
+  if (states.length > maxStates) {
+    const ranked = states
+      .map((s, i) => ({ s, i, hold: s.hold_ms ?? 0 }))
+      .sort((a, b) => b.hold - a.hold)
+      .slice(0, maxStates)
+      .sort((a, b) => a.i - b.i);
+    kept = ranked.map((r) => r.s);
+    dropped = states.length - kept.length;
+  }
+
+  const totalHold = kept.reduce((n, s) => n + Math.max(1, s.hold_ms ?? 1), 0);
+  let t = start;
+  const scheduled = kept.map((state, i) => {
+    const share = Math.max(1, state.hold_ms ?? 1) / totalHold;
+    const span = i === kept.length - 1 ? start + usable - t : Math.max(minDwell, usable * share);
+    const at = Number(t.toFixed(2));
+    t = Math.min(start + usable, t + span);
+    return { state, at, until: Number(t.toFixed(2)) };
+  });
+
+  return { scheduled, dropped };
+}
+
+/** One state as absolutely-positioned styled rows. */
+function stateHtml(sceneId, index, state, { rowHeight, charWidth }) {
+  const rows = state.grid
+    .map((row) => {
+      const runs = row.runs
+        .map(
+          (run) =>
+            `<span style="left:${(run.col * charWidth).toFixed(1)}px;color:${colourFor(run.fg)}` +
+            `${run.bold ? ";font-weight:600" : ""}${run.dim ? ";opacity:.7" : ""}">${esc(run.text)}</span>`,
+        )
+        .join("");
+      return `        <div class="trow" style="top:${(row.row * rowHeight).toFixed(1)}px">${runs}</div>`;
+    })
+    .join("\n");
+  return [
+    `      <div class="tstate" id="tstate-${sceneId}-${index}">`,
+    rows,
+    `      </div>`,
+  ].join("\n");
+}
+
+/**
+ * @returns {{html: string, tweens: string[], css: string, dropped: number}}
+ */
+export function buildTerminalScene({ scene, session, start, duration, geometry, px }) {
+  const cols = session.environment?.cols ?? 100;
+  const rows = session.environment?.rows ?? 30;
+
+  /* Sized so the widest captured line fits: the terminal is the product here,
+     and reflowing its output would misrepresent it. */
+  /* Sized from the widest row that is actually used, not the capture's declared
+     width: a session captured at 96 columns whose longest line is 70 wastes a
+     third of the frame if sized on the declaration. Rows are never reflowed —
+     rewrapping terminal output misrepresents what the terminal did — so a
+     capture genuinely too wide for the shape is reported rather than cropped
+     silently. */
+  const widestUsed = Math.max(
+    ...session.states.flatMap((s) =>
+      s.grid.map((row) => row.runs.reduce((n, r) => Math.max(n, r.col + r.text.length), 0)),
+    ),
+    1,
+  );
+  const effectiveCols = Math.min(cols, widestUsed);
+  const charWidth = Math.max(5, Math.floor((geometry.width * 0.82) / effectiveCols));
+  const tooWide = charWidth <= 5 && widestUsed * 6 > geometry.width * 0.9;
+  const rowHeight = Math.round(charWidth * 2.05);
+  const usedRows = Math.max(...session.states.map((s) => (s.grid.at(-1)?.row ?? 0) + 1), 1);
+
+  const { scheduled, dropped } = scheduleStates(session.states, { start, duration });
+
+  const html = [
+    `      <div class="term" id="term-${scene.id}" style="--tw:${charWidth}px;--th:${rowHeight}px">`,
+    `        <div class="tbar"><span class="tdot"></span><span class="tlabel">${esc(session.invocation.display_command)}</span></div>`,
+    `        <div class="tview" style="height:${(usedRows * rowHeight + rowHeight).toFixed(0)}px">`,
+    ...scheduled.map(({ state }, i) => stateHtml(scene.id, i, state, { rowHeight, charWidth })),
+    `        </div>`,
+    `      </div>`,
+  ].join("\n");
+
+  /* Every state hidden, then exactly one shown at a time. Zero-duration sets
+     at thresholds: the renderer seeks, so a state that depended on having
+     passed through the previous one would be wrong on a backwards sample. */
+  const tweens = [
+    `      tl.set([${scheduled.map((_, i) => `"#tstate-${scene.id}-${i}"`).join(", ")}], { autoAlpha: 0 }, ${Number(start.toFixed(2))});`,
+    ...scheduled.flatMap(({ at }, i) => [
+      `      tl.set("#tstate-${scene.id}-${i}", { autoAlpha: 1 }, ${at});`,
+      ...(i > 0 ? [`      tl.set("#tstate-${scene.id}-${i - 1}", { autoAlpha: 0 }, ${at});`] : []),
+    ]),
+  ];
+
+  return { html, tweens, dropped, states: scheduled.length, tooWide, columns: effectiveCols };
+}
+
+export const TERMINAL_CSS = `
+      .term {
+        position: relative;
+        width: 100%;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        overflow: hidden;
+        font-family: var(--mono);
+      }
+      .tbar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 16px;
+        border-bottom: 1px solid var(--border);
+      }
+      .tdot { width: 9px; height: 9px; border-radius: 50%; background: var(--accent); }
+      .tlabel { font-size: 0.62em; color: var(--muted); letter-spacing: .01em; }
+      .tview { position: relative; padding: 14px 16px; }
+      .tstate { position: absolute; inset: 14px 16px; opacity: 0; }
+      .trow { position: absolute; left: 0; right: 0; height: var(--th); line-height: var(--th); white-space: pre; }
+      .trow span { position: absolute; font-size: calc(var(--tw) * 1.68); }`;

--- a/cli/lib/compile/terminal-scene.mjs
+++ b/cli/lib/compile/terminal-scene.mjs
@@ -179,4 +179,9 @@ export const TERMINAL_CSS = `
       .tview { position: relative; padding: 14px 16px; }
       .tstate { position: absolute; inset: 14px 16px; opacity: 0; }
       .trow { position: absolute; left: 0; right: 0; height: var(--th); line-height: var(--th); white-space: pre; }
-      .trow span { position: absolute; font-size: calc(var(--tw) * 1.68); }`;
+      /* Runs are positioned on a --tw grid, so a glyph advance wider than --tw
+         makes a long run overrun its own cells and spill past the panel. The
+         factor has to assume the widest advance a mono stack might have
+         (~0.69em) rather than the narrowest, since under-filling a cell reads
+         as tracking and overfilling reads as clipped text. */
+      .trow span { position: absolute; font-size: calc(var(--tw) * 1.44); }`;

--- a/cli/lib/detect/fidelity.mjs
+++ b/cli/lib/detect/fidelity.mjs
@@ -54,6 +54,10 @@ export function extractRenderedText(html) {
   for (const m of html.matchAll(tag("p", "lead|line"))) {
     push("copy", m[2], idOf(m[0]));
   }
+  /* The compiler no longer emits kickers — a scene's role is brag's filing
+     system, not something a viewer should read. A hand-edited composition may
+     still carry one, and it has to keep being classified as structure so the
+     fidelity pass does not report it as an unsourced claim. */
   for (const m of html.matchAll(tag("p", "kicker"))) {
     push("kicker", m[2]);
   }

--- a/cli/lib/detect/fidelity.mjs
+++ b/cli/lib/detect/fidelity.mjs
@@ -29,6 +29,58 @@ const loose = (s) => norm(s).toLowerCase().replace(/[^a-z0-9 ]+/g, "").trim();
  * Terminal rows are read per row rather than per run, since a row is what a
  * viewer reads; runs are a styling detail.
  */
+/**
+ * Every file a viewer's eyes end up reading.
+ *
+ * `index.html` stopped being the whole composition the moment frames became
+ * sub-compositions: it holds the mounts, and the copy lives in the files those
+ * mounts point at. Reading only the index returned zero strings and reported
+ * `0/0 resolve to a source`, which prints as a pass. A fidelity layer that
+ * checks nothing is worse than one that fails, because nobody investigates a
+ * tick.
+ *
+ * @param read (relativePath) => string|null — resolves a `data-composition-src`
+ */
+export function extractRenderedTree(indexHtml, read) {
+  const out = extractRenderedText(indexHtml);
+  const seen = new Set();
+  for (const m of indexHtml.matchAll(/data-composition-src="([^"]+)"/g)) {
+    const src = m[1];
+    if (seen.has(src)) continue;
+    seen.add(src);
+    const contents = read(src);
+    if (contents) out.push(...extractAuthoredText(contents));
+  }
+  return out;
+}
+
+/**
+ * Visible strings in a frame nobody generated.
+ *
+ * The scaffold's extractor matches its own class names, which a designed frame
+ * has no reason to use. So this reads structurally instead: strip anything
+ * that is not rendered, then take the text of every leaf element. It over-reads
+ * rather than under-reads on purpose — a string wrongly listed is a finding
+ * someone dismisses, and a string missed is a claim nobody checked.
+ */
+export function extractAuthoredText(html) {
+  const body = html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ");
+
+  const out = [];
+  /* Leaf elements only: an ancestor's text is its descendants' concatenated,
+     which would report "tapedeck recordnpm test" as an unsourced line of its own. */
+  for (const m of body.matchAll(/<([a-z][\w-]*)\b([^>]*)>([^<]*)<\/\1>/gi)) {
+    const value = norm(m[3]);
+    if (!value) continue;
+    const id = (m[2].match(/(?:^|\s)id="([^"]*)"/) ?? [])[1] ?? null;
+    out.push({ kind: "copy", text: value, id });
+  }
+  return out;
+}
+
 export function extractRenderedText(html) {
   const out = [];
   const push = (kind, text, id) => {
@@ -102,6 +154,11 @@ export function checkFidelity({ rendered, model, positioning, captureLines = [] 
 
   for (const item of rendered) {
     if (item.kind === "kicker") continue;
+    /* Chrome, not copy. A run with no letters and no digits asserts nothing —
+       a shell prompt's `$`, an arrow, a rule. Demanding a source for those
+       means either a frame cannot draw a prompt or someone adds "$" to the
+       product model, and both are worse than the rule. */
+    if (!/[a-z0-9]/i.test(item.text)) continue;
     checked++;
 
     if (exact.has(item.text)) {
@@ -110,6 +167,18 @@ export function checkFidelity({ rendered, model, positioning, captureLines = [] 
     }
     const key = loose(item.text);
     if (looseSet.has(key) || structural.has(key)) {
+      resolved++;
+      continue;
+    }
+
+    /* A fragment of a sourced string is sourced.
+       Splitting a line across elements is ordinary craft — a hero sentence
+       revealed clause by clause, a figure labelling the two numbers out of the
+       sentence that states them. Reading the rendered tree leaf by leaf sees
+       those pieces individually, and reporting each one as an invented claim
+       buries the real findings. Showing less of a true string cannot make it
+       untrue; showing MORE can, and that is the paraphrase case below. */
+    if (key && [...looseSet, ...structural].some((source) => source.includes(key))) {
       resolved++;
       continue;
     }

--- a/cli/lib/detect/fidelity.mjs
+++ b/cli/lib/detect/fidelity.mjs
@@ -1,0 +1,164 @@
+/**
+ * Layer 4: does the video only say things the product can back up?
+ *
+ * Every string that reaches the screen must resolve to a source — a verbatim
+ * string extracted from the project, a line a captured command actually
+ * printed, or a claim bound to a proof. Anything else is the video asserting
+ * something on the product's behalf, which is the failure mode that makes a
+ * launch video embarrassing rather than wrong.
+ *
+ * This reads the compiled composition rather than the scene graph. The graph
+ * is what brag intended; the composition is what a viewer will see, and the
+ * gap between those two is exactly what a fidelity check is for.
+ */
+
+const norm = (s) =>
+  String(s)
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+
+const loose = (s) => norm(s).toLowerCase().replace(/[^a-z0-9 ]+/g, "").trim();
+
+/**
+ * Visible strings in a compiled composition, tagged by where they sit.
+ *
+ * Terminal rows are read per row rather than per run, since a row is what a
+ * viewer reads; runs are a styling detail.
+ */
+export function extractRenderedText(html) {
+  const out = [];
+  const push = (kind, text, id) => {
+    const value = norm(text);
+    if (value) out.push({ kind, text: value, id: id ?? null });
+  };
+
+  /* Attribute order is not ours to assume. Opening a project with
+     `hyperframes check` rewrites index.html and injects its own identity
+     attribute ahead of the class, and a checker that matched on position
+     silently found nothing at all — a fidelity layer reporting 0/0 strings is
+     worse than one that fails, because it reads as a pass. */
+  const tag = (name, cls) =>
+    new RegExp(
+      "<" + name + '\\b[^>]*class="[^"]*\\b(' + cls + ')\\b[^"]*"[^>]*>([\\s\\S]*?)</' + name + ">",
+      "g",
+    );
+  /* Anchored to an attribute boundary: a bare /id="/ also matches inside
+     `data-hf-id="hf-1"`, which would attribute every finding to HyperFrames'
+     injected identity instead of the scene that owns the line. */
+  const idOf = (open) => (open.match(/(?:^|\s)id="([^"]*)"/) ?? [])[1] ?? null;
+
+  for (const m of html.matchAll(tag("p", "lead|line"))) {
+    push("copy", m[2], idOf(m[0]));
+  }
+  for (const m of html.matchAll(tag("p", "kicker"))) {
+    push("kicker", m[2]);
+  }
+  for (const m of html.matchAll(tag("span", "tlabel"))) {
+    push("terminal_command", m[2]);
+  }
+  for (const m of html.matchAll(tag("div", "trow"))) {
+    push("terminal_output", m[2].replace(/<[^>]+>/g, ""));
+  }
+  return out;
+}
+
+/**
+ * @returns {{findings: object[], resolved: number, checked: number}}
+ */
+export function checkFidelity({ rendered, model, positioning, captureLines = [] }) {
+  /* What the product can be quoted as saying. */
+  const verbatim = (model.verbatim_copy ?? []).map((v) => v.text);
+  const claims = (positioning?.claims ?? []).map((c) => c.text);
+  const captured = captureLines;
+
+  const exact = new Set([...verbatim, ...captured].map(norm));
+  const looseSet = new Set([...verbatim, ...captured, ...claims].map(loose));
+
+  /* Narrative connective tissue a video needs and no source will contain.
+     Kickers are the storyboard's own role names, not claims about the tool. */
+  const structural = new Set(
+    [
+      model.name,
+      model.one_line,
+      positioning?.angle,
+      positioning?.action,
+      ...(model.proof ?? []).map((p) => p.claim),
+    ]
+      .filter(Boolean)
+      .map(loose),
+  );
+
+  const findings = [];
+  let resolved = 0;
+  let checked = 0;
+
+  for (const item of rendered) {
+    if (item.kind === "kicker") continue;
+    checked++;
+
+    if (exact.has(item.text)) {
+      resolved++;
+      continue;
+    }
+    const key = loose(item.text);
+    if (looseSet.has(key) || structural.has(key)) {
+      resolved++;
+      continue;
+    }
+
+    /* A terminal row is real by construction — it came out of a command — so a
+       row that does not match is a sign the capture and the composition have
+       drifted apart, which is a different and more serious problem. */
+    if (item.kind === "terminal_output" || item.kind === "terminal_command") {
+      findings.push({
+        code: "capture_drift",
+        scene: item.id,
+        at: null,
+        message: `the composition shows "${truncate(item.text)}" as terminal output, but no captured session printed it`,
+        fix: "recompile after capturing, or stop hand-writing terminal content",
+      });
+      continue;
+    }
+
+    /* Partial credit: copy that contains a sourced string is a paraphrase
+       wrapped around real material, which is worth flagging more gently than
+       a wholly invented line. */
+    const contains = [...verbatim, ...captured].find((v) => v && key.includes(loose(v)) && loose(v).length > 8);
+    findings.push({
+      code: contains ? "paraphrased_source" : "unsourced_copy",
+      scene: item.id,
+      at: null,
+      message: contains
+        ? `"${truncate(item.text)}" wraps a sourced string rather than quoting it`
+        : `"${truncate(item.text)}" appears on screen with nothing in the product model behind it`,
+      fix: contains
+        ? "quote the source exactly, or add the paraphrase as its own verbatim entry"
+        : "add it to verbatim_copy with a real source, bind it to a proof, or cut it",
+    });
+  }
+
+  /* Forbidden claims are checked against everything, kickers included. */
+  for (const forbidden of model.forbidden_claims ?? []) {
+    const needle = loose(forbidden);
+    if (!needle) continue;
+    for (const item of rendered) {
+      if (loose(item.text).includes(needle)) {
+        findings.push({
+          code: "forbidden_claim_rendered",
+          scene: item.id,
+          at: null,
+          message: `the composition shows "${truncate(item.text)}", which restates a forbidden claim: "${forbidden}"`,
+          fix: "cut it; the product model says this is not a claim this product makes",
+        });
+      }
+    }
+  }
+
+  return { findings, resolved, checked };
+}
+
+const truncate = (s, n = 64) => (s.length > n ? `${s.slice(0, n)}…` : s);

--- a/cli/lib/detect/index.mjs
+++ b/cli/lib/detect/index.mjs
@@ -42,7 +42,7 @@ export function detectFlatFrames(frames) {
           : `${f.at}s is ${f.tone.dark ? "black" : "flat"} (tonal range ${f.tone.stdDev})${f.scene ? ` in "${f.scene}"` : ""}`,
       fix:
         f.kind === "frame_zero"
-          ? "bake a settled frame as frame zero"
+          ? "open on something settled — frame zero is the thumbnail, and splicing a later frame over it puts the middle of the film in front of its own opening"
           : "move the cut, or give the moment something to show",
     });
   }

--- a/cli/lib/detect/index.mjs
+++ b/cli/lib/detect/index.mjs
@@ -78,41 +78,71 @@ export function detectCaptionZone(frames, { zone = CAPTION_ZONE, minInk = 0.35 }
 }
 
 /**
- * Two scenes that look the same.
+ * Compositions the film leans on too hard, and cuts that land on the same one.
  *
  * Compares one representative frame per scene, so a repeated layout is caught
  * while a scene's own frames — which should of course resemble each other —
  * are not. A repeat is only interesting between *different* scenes.
+ *
+ * What counts as too much is the same budget the layout assigner spends
+ * against: a composition may carry up to 40% of a film. Failing every pair
+ * that matched would contradict that outright — a world ships four layouts, so
+ * a seven-scene film cannot give each scene its own and the two rules would
+ * make each other unsatisfiable. Two things are actually wrong: one picture
+ * carrying more of the film than the budget allows, and a cut that lands back
+ * on the picture it just left, which reads as no cut at all.
  */
-export function detectRepeatedLayouts(frames, { maxDistance = 1 } = {}) {
+export function detectRepeatedLayouts(frames, { maxDistance = 1, budgetShare = 0.4 } = {}) {
   const byScene = new Map();
   for (const f of frames) {
     if (!f.scene || f.kind !== "midpoint") continue;
     if (!byScene.has(f.scene)) byScene.set(f.scene, f);
   }
 
-  const entries = [...byScene.values()];
+  const entries = [...byScene.values()].filter((f) => layoutSignature(f) !== null);
   const out = [];
-  for (let i = 0; i < entries.length; i++) {
-    for (let j = i + 1; j < entries.length; j++) {
-      const a = entries[i];
-      const b = entries[j];
-      const sa = layoutSignature(a);
-      const sb = layoutSignature(b);
-      if (sa === null || sb === null) continue;
+  if (!entries.length) return out;
 
-      const distance = hamming(sa, sb);
-      if (distance > maxDistance) continue;
-      out.push({
-        code: "repeated_layout",
-        scene: b.scene,
-        at: b.at,
-        message:
-          `"${a.scene}" and "${b.scene}" put content in the same places ` +
-          `(layout distance ${distance}) — the video shows the same picture twice with different words in it`,
-        fix: "change the composition, the camera, or what is on screen — not only the copy",
-      });
-    }
+  /* Group scenes whose compositions are within maxDistance of each other. */
+  const groups = [];
+  for (const entry of entries) {
+    const sig = layoutSignature(entry);
+    const group = groups.find((g) => hamming(g.signature, sig) <= maxDistance);
+    if (group) group.scenes.push(entry);
+    else groups.push({ signature: sig, scenes: [entry] });
+  }
+
+  const budget = Math.max(2, Math.floor(entries.length * budgetShare));
+  for (const group of groups) {
+    if (group.scenes.length <= budget) continue;
+    const last = group.scenes[group.scenes.length - 1];
+    out.push({
+      code: "repeated_layout",
+      scene: last.scene,
+      at: last.at,
+      message:
+        `${group.scenes.length} of ${entries.length} scenes put content in the same places ` +
+        `(${group.scenes.map((s) => `"${s.scene}"`).join(", ")}) — more than the ${budget} a single ` +
+        "composition may carry, so the film reads as one picture with the words changing",
+      fix: "change the composition, the camera, or what is on screen — not only the copy",
+    });
+  }
+
+  /* A cut that lands back where it started. */
+  for (let i = 1; i < entries.length; i++) {
+    const a = entries[i - 1];
+    const b = entries[i];
+    const distance = hamming(layoutSignature(a), layoutSignature(b));
+    if (distance > maxDistance) continue;
+    out.push({
+      code: "repeated_layout",
+      scene: b.scene,
+      at: b.at,
+      message:
+        `"${a.scene}" cuts to "${b.scene}" and the content stays in the same places ` +
+        `(layout distance ${distance}) — consecutive scenes reading as one`,
+      fix: "give one of them a different composition, or hand something across the cut that moves",
+    });
   }
   return out;
 }

--- a/cli/lib/detect/index.mjs
+++ b/cli/lib/detect/index.mjs
@@ -1,0 +1,164 @@
+/**
+ * Layer 2 detectors: what a person would notice looking at the frames.
+ *
+ * Each returns findings shaped `{code, scene, at, message, fix}`. They are
+ * deliberately conservative — a review that cries wolf gets switched off, and
+ * a switched-off review is worse than none.
+ */
+
+import { hamming } from "../watch/pixels.mjs";
+
+/** Where the caption band starts, as a fraction of frame height. */
+const CAPTION_ZONE = 0.83;
+
+/**
+ * Moments where something is supposed to be on screen and composed.
+ *
+ * Frames sampled on and just after a cut are mid-transition by construction:
+ * the outgoing scene has left and the incoming one has not arrived. Judging
+ * those as black frames or as content in the wrong place reports the technique
+ * as the defect, and a detector that flags every cut is one nobody reads.
+ */
+const COMPOSED = new Set(["frame_zero", "midpoint", "settled_read", "final"]);
+
+/**
+ * A frame with no tonal range: black, white, or a fade caught mid-dip.
+ * Frame zero is judged hardest, because it is the thumbnail.
+ */
+export function detectFlatFrames(frames) {
+  const out = [];
+  for (const f of frames) {
+    if (!f.tone.flat) continue;
+    if (!COMPOSED.has(f.kind)) continue;
+    /* The final frame is allowed to rest on a clean ground. */
+    if (f.kind === "final") continue;
+    out.push({
+      code: f.tone.dark ? "black_frame" : "flat_frame",
+      scene: f.scene ?? null,
+      at: f.at,
+      message:
+        f.kind === "frame_zero"
+          ? `frame zero is ${f.tone.dark ? "black" : "flat"} (tonal range ${f.tone.stdDev}) — that is the thumbnail every platform will show`
+          : `${f.at}s is ${f.tone.dark ? "black" : "flat"} (tonal range ${f.tone.stdDev})${f.scene ? ` in "${f.scene}"` : ""}`,
+      fix:
+        f.kind === "frame_zero"
+          ? "bake a settled frame as frame zero"
+          : "move the cut, or give the moment something to show",
+    });
+  }
+  return out;
+}
+
+/**
+ * Content sitting in the caption band, where a platform's own subtitles land.
+ * Measured from ink rather than DOM boxes, so it catches whatever is actually
+ * visible there.
+ */
+export function detectCaptionZone(frames, { zone = CAPTION_ZONE, minInk = 0.35 } = {}) {
+  const out = [];
+  for (const f of frames) {
+    if (!f.ink?.length) continue;
+    if (!COMPOSED.has(f.kind)) continue;
+    const firstRow = Math.floor(f.ink.length * zone);
+    const band = f.ink.slice(firstRow);
+    const worst = Math.max(0, ...band);
+    if (worst < minInk) continue;
+    const row = firstRow + band.indexOf(worst);
+    out.push({
+      code: "caption_zone_collision",
+      scene: f.scene ?? null,
+      at: f.at,
+      message:
+        `content sits in the caption band at ${f.at}s${f.scene ? ` in "${f.scene}"` : ""} ` +
+        `(ink ${worst.toFixed(2)} at ${(row / f.ink.length * 100).toFixed(0)}% down the frame)`,
+      fix: `keep meaningful content above ${(zone * 100).toFixed(0)}% of the frame height, or mark the element as intentional lower-third copy`,
+    });
+  }
+  return out;
+}
+
+/**
+ * Two scenes that look the same.
+ *
+ * Compares one representative frame per scene, so a repeated layout is caught
+ * while a scene's own frames — which should of course resemble each other —
+ * are not. A repeat is only interesting between *different* scenes.
+ */
+export function detectRepeatedLayouts(frames, { maxDistance = 1 } = {}) {
+  const byScene = new Map();
+  for (const f of frames) {
+    if (!f.scene || f.kind !== "midpoint") continue;
+    if (!byScene.has(f.scene)) byScene.set(f.scene, f);
+  }
+
+  const entries = [...byScene.values()];
+  const out = [];
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      const a = entries[i];
+      const b = entries[j];
+      const sa = layoutSignature(a);
+      const sb = layoutSignature(b);
+      if (sa === null || sb === null) continue;
+
+      const distance = hamming(sa, sb);
+      if (distance > maxDistance) continue;
+      out.push({
+        code: "repeated_layout",
+        scene: b.scene,
+        at: b.at,
+        message:
+          `"${a.scene}" and "${b.scene}" put content in the same places ` +
+          `(layout distance ${distance}) — the video shows the same picture twice with different words in it`,
+        fix: "change the composition, the camera, or what is on screen — not only the copy",
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * A layout signature: which horizontal bands actually carry content.
+ *
+ * Average-hash over the whole frame is the obvious choice and the wrong one
+ * here. On a dark, sparse composition almost every frame is mostly background,
+ * so two genuinely different scenes land a few bits apart and the threshold has
+ * to be set so loose it stops meaning anything. Layout is *where content sits*,
+ * so the signature is built from the ink profile: sixteen bands, one bit each.
+ */
+export function layoutSignature(frame, { bands = 16, threshold = 0.2 } = {}) {
+  if (!frame.ink?.length) return null;
+  let bits = 0n;
+  for (let b = 0; b < bands; b++) {
+    const from = Math.floor((b / bands) * frame.ink.length);
+    const to = Math.max(from + 1, Math.floor(((b + 1) / bands) * frame.ink.length));
+    const slice = frame.ink.slice(from, to);
+    if (Math.max(0, ...slice) >= threshold) bits |= 1n << BigInt(b);
+  }
+  return bits;
+}
+
+/**
+ * Copy that cannot be read in the time it is given. Static: it comes from the
+ * timing plan rather than the pixels, because the number is knowable before a
+ * single frame is rendered.
+ */
+export function detectUnreadableCopy(tight) {
+  return tight.flatMap(({ scene, lines }) =>
+    lines.map((line) => ({
+      code: "reading_floor_violated",
+      scene: scene.id,
+      at: line.settled,
+      message:
+        `"${line.text}" needs ${line.floor}s to read but "${scene.id}" gives it ` +
+        `${Math.max(0, scene.start + scene.duration - line.settled).toFixed(2)}s settled`,
+      fix: "lengthen the scene or shorten the line — the reading floor does not move",
+    })),
+  );
+}
+
+export function summarize(findings) {
+  const byCode = {};
+  for (const f of findings) byCode[f.code] = (byCode[f.code] ?? 0) + 1;
+  return byCode;
+}

--- a/cli/lib/detect/narrative.mjs
+++ b/cli/lib/detect/narrative.mjs
@@ -1,0 +1,170 @@
+/**
+ * Layer 3: did the video communicate what it was built to communicate?
+ *
+ * The reviewer sees the frames and the text that reached the screen, and
+ * nothing else — no scene graph, no purposes, no claim list. That constraint is
+ * the whole design. An agent handed the plan alongside the render will grade
+ * the plan; the only question worth asking is what someone takes away from
+ * watching, and you cannot ask that of a reviewer who has been told the answer.
+ *
+ * Agreement is computed here rather than rated by the reviewer, for the same
+ * reason. And the result is a report, not a gate: a stochastic grader must not
+ * block a delivery until its accuracy has been measured against labelled
+ * fixtures and found good enough to trust.
+ */
+
+const loose = (s) =>
+  String(s ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const words = (s) => new Set(loose(s).split(" ").filter((w) => w.length > 3));
+
+/** How much of `expected` the answer covers, 0 to 1. */
+function overlap(answer, expected) {
+  const a = words(answer);
+  const e = words(expected);
+  if (!e.size) return 1;
+  let hit = 0;
+  for (const w of e) if (a.has(w)) hit++;
+  return Number((hit / e.size).toFixed(2));
+}
+
+export const QUESTIONS = [
+  "product",
+  "problem",
+  "proof",
+  "scenes",
+  "unsupported",
+  "silent",
+  "readable",
+  "ending",
+];
+
+/**
+ * Compare a blind review against what the video was supposed to do.
+ *
+ * @returns {{agreement: number, checks: object[], findings: object[]}}
+ */
+export function scoreNarrative({ answers, model, positioning, graph }) {
+  const checks = [];
+  const findings = [];
+  const add = (id, ok, detail, weight = 1) => checks.push({ id, ok, detail, weight });
+
+  /* Did they come away knowing what it is? */
+  const productHit =
+    loose(answers.product).includes(loose(model.name)) ||
+    overlap(answers.product, model.one_line ?? "") >= 0.3;
+  add("product", productHit, `said "${answers.product}"`, 2);
+  if (!productHit) {
+    findings.push({
+      code: "product_unclear",
+      scene: null,
+      at: null,
+      message: `a viewer watching this called it "${answers.product}" — the product model says ${model.name}`,
+      fix: "put the product's own name and what it does on screen, plainly",
+    });
+  }
+
+  const problemScore = overlap(answers.problem, model.problem ?? "");
+  add("problem", problemScore >= 0.25, `${(problemScore * 100).toFixed(0)}% overlap with the stated problem`, 2);
+  if (problemScore < 0.25) {
+    findings.push({
+      code: "problem_not_conveyed",
+      scene: null,
+      at: null,
+      message: `the problem read as "${answers.problem}" rather than what the product model states`,
+      fix: "show the problem happening instead of naming it",
+    });
+  }
+
+  /* Proof: did the evidence the video was built around actually land? */
+  const required = new Set((graph?.scenes ?? []).flatMap((s) => s.required_proof ?? []));
+  const claimed = (answers.proof ?? []).join(" ");
+  const landed = [...required].filter((id) => {
+    const proof = (model.proof ?? []).find((p) => p.id === id);
+    return proof && overlap(claimed, proof.claim) >= 0.25;
+  });
+  add(
+    "proof",
+    required.size === 0 || landed.length > 0,
+    `${landed.length}/${required.size} required proofs recognised`,
+    2,
+  );
+  for (const id of [...required].filter((r) => !landed.includes(r))) {
+    findings.push({
+      code: "proof_did_not_land",
+      scene: null,
+      at: null,
+      message: `proof "${id}" is required by a scene but a blind viewer did not report seeing it`,
+      fix: "show the evidence longer, larger, or as the only thing on screen",
+    });
+  }
+
+  /* Scene count, loosely: a viewer who saw half the moments watched a
+     different video from the one that was planned. */
+  const planned = (graph?.scenes ?? []).length;
+  const seen = (answers.scenes ?? []).length;
+  const closeEnough =
+    planned === 0 || Math.abs(seen - planned) <= Math.max(1, Math.floor(planned * 0.34));
+  add("scenes", closeEnough, `${seen} moments reported against ${planned} planned`);
+
+  /* Anything read as unsupported is worth more than the rest of the review. */
+  add(
+    "unsupported",
+    (answers.unsupported ?? []).length === 0,
+    `${(answers.unsupported ?? []).length} unsupported claim(s) reported`,
+    2,
+  );
+  for (const claim of answers.unsupported ?? []) {
+    findings.push({
+      code: "read_as_unsupported",
+      scene: null,
+      at: null,
+      message: `a blind viewer read "${claim}" as unsupported`,
+      fix: "show the evidence beside the claim, or drop the claim",
+    });
+  }
+
+  const wantsSilent = graph?.audio?.silent_comprehension !== false;
+  add("silent", !wantsSilent || answers.silent?.yes === true, answers.silent?.because ?? "");
+  if (wantsSilent && answers.silent?.yes === false) {
+    findings.push({
+      code: "needs_sound",
+      scene: null,
+      at: null,
+      message: `the video is meant to work muted, but a viewer said it does not: ${answers.silent.because}`,
+      fix: "carry the argument in the picture, not only the copy",
+    });
+  }
+
+  add(
+    "readable",
+    (answers.readable ?? []).length === 0,
+    `${(answers.readable ?? []).length} unreadable moment(s)`,
+    2,
+  );
+  for (const line of answers.readable ?? []) {
+    findings.push({
+      code: "read_too_fast",
+      scene: null,
+      at: null,
+      message: `a viewer could not read "${line}" in the time it was up`,
+      fix: "raise its reading floor, or cut the line",
+    });
+  }
+
+  const endingHit = overlap(answers.ending, positioning?.action ?? "") >= 0.2;
+  add("ending", !positioning?.action || endingHit, `read the ending as "${answers.ending}"`);
+
+  const total = checks.reduce((n, c) => n + c.weight, 0);
+  const scored = checks.reduce((n, c) => n + (c.ok ? c.weight : 0), 0);
+
+  return {
+    agreement: Number((scored / Math.max(1, total)).toFixed(2)),
+    checks,
+    findings,
+  };
+}

--- a/cli/lib/determinism.mjs
+++ b/cli/lib/determinism.mjs
@@ -1,0 +1,65 @@
+/**
+ * Determinism fingerprinting.
+ *
+ * "Compile twice, get the same bytes" is the property a scoped revision later
+ * depends on: if recompiling an untouched scene produces different output, no
+ * one can prove a revision only changed what it claimed.
+ *
+ * One wrinkle is upstream, not ours. Opening a project with `hyperframes check`
+ * rewrites index.html in place — it normalises the markup and injects
+ * `data-hf-id="hf-xxxx"` identity attributes for Studio's timeline, freshly
+ * generated each time. So the fingerprint compares *semantic* content: foreign
+ * identity attributes and HTML normalisation are stripped before hashing, and
+ * everything brag actually authored is compared exactly.
+ */
+
+import path from "node:path";
+import fs from "node:fs";
+import { sha256, walkFiles } from "./util.mjs";
+
+const TEXT = /\.(html?|md|json|css|js|mjs|txt|svg)$/i;
+
+/** Remove what HyperFrames stamps into a file it has opened. */
+export function normalizeForCompare(rel, contents) {
+  if (!/\.html?$/i.test(rel)) return contents;
+  return contents
+    .replace(/\s*data-hf-id="[^"]*"/g, "")
+    .replace(/<!DOCTYPE html>/i, "<!doctype html>")
+    /* Studio re-serialises void elements and collapses attribute whitespace;
+       neither changes meaning, so neither should fail a determinism check. */
+    .replace(/\s*\/>/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/[ \t]+/g, " ")
+    .replace(/\r\n/g, "\n")
+    .replace(/\n\s*\n/g, "\n")
+    .trim();
+}
+
+/**
+ * @returns {Map<string,string>} relative path → content hash
+ */
+export function fingerprintTree(root) {
+  const out = new Map();
+  for (const rel of walkFiles(root)) {
+    const abs = path.join(root, rel);
+    const buf = fs.readFileSync(abs);
+    const hash = TEXT.test(rel)
+      ? sha256(normalizeForCompare(rel, buf.toString("utf8")))
+      : sha256(buf);
+    out.set(rel, hash);
+  }
+  return out;
+}
+
+/**
+ * Compare two fingerprints.
+ * @returns {{identical: boolean, added: string[], removed: string[], changed: string[]}}
+ */
+export function diffFingerprints(before, after) {
+  const added = [...after.keys()].filter((k) => !before.has(k)).sort();
+  const removed = [...before.keys()].filter((k) => !after.has(k)).sort();
+  const changed = [...before.keys()]
+    .filter((k) => after.has(k) && before.get(k) !== after.get(k))
+    .sort();
+  return { identical: !added.length && !removed.length && !changed.length, added, removed, changed };
+}

--- a/cli/lib/hyperframes.mjs
+++ b/cli/lib/hyperframes.mjs
@@ -1,0 +1,396 @@
+/**
+ * The HyperFrames bridge.
+ *
+ * Brag does not own motion vocabulary, rendering, or linting — HyperFrames
+ * does. This module locates the installed skill pack and reads its indices at
+ * runtime. Nothing is ever vendored: a copied rule list silently desyncs on the
+ * next HyperFrames upgrade, and a stale vocabulary produces compositions that
+ * cite motion ids which no longer exist.
+ *
+ * `brag doctor` fails loudly when anything here cannot be resolved.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { envError, exists, warn } from "./util.mjs";
+
+/* ------------------------------------------------------------------ location */
+
+const CANDIDATE_ROOTS = () =>
+  [
+    process.env.BRAG_SKILLS_DIR,
+    process.env.CLAUDE_SKILLS_DIR,
+    path.join(os.homedir(), ".claude", "skills"),
+    path.join(process.cwd(), ".claude", "skills"),
+    path.join(os.homedir(), ".agents", "skills"),
+  ].filter(Boolean);
+
+let cachedRoot;
+
+/** Directory containing hyperframes-core, hyperframes-animation, … */
+export function skillsRoot() {
+  if (cachedRoot !== undefined) return cachedRoot;
+  for (const root of CANDIDATE_ROOTS()) {
+    if (exists(path.join(root, "hyperframes-core")) && exists(path.join(root, "hyperframes-animation"))) {
+      cachedRoot = root;
+      return root;
+    }
+  }
+  cachedRoot = null;
+  return null;
+}
+
+export function requireSkillsRoot() {
+  const root = skillsRoot();
+  if (!root) {
+    throw envError(
+      "cannot find the HyperFrames skill pack.\n" +
+        "Install it with `npx hyperframes skills`, then restart the agent session.\n" +
+        `Looked in:\n${CANDIDATE_ROOTS().map((r) => `  ${r}`).join("\n")}`,
+    );
+  }
+  return root;
+}
+
+/** Every path brag depends on, and what breaks without it. */
+export function requiredPaths(root = requireSkillsRoot()) {
+  return [
+    {
+      id: "frame-packets-core",
+      file: path.join(root, "hyperframes-core", "scripts", "lib", "frame-packets-core.mjs"),
+      why: "builds frame-worker packets and validates cited motion rule ids",
+    },
+    {
+      id: "rules-index",
+      file: path.join(root, "hyperframes-animation", "rules-index.md"),
+      why: "the atomic motion vocabulary a scene may cite",
+    },
+    {
+      id: "blueprints-index",
+      file: path.join(root, "hyperframes-animation", "blueprints-index.md"),
+      why: "time-coded scene blueprints mapped to storyboard roles",
+    },
+    {
+      id: "transition-registry",
+      file: path.join(root, "hyperframes-animation", "transitions", "TRANSITION-REGISTRY.md"),
+      why: "the machine-readable transitions a seam may use",
+    },
+    {
+      id: "seam-gate",
+      file: path.join(root, "motion-doctrine", "scripts", "seam-gate.mjs"),
+      why: "numerically verifies every seam against the vector ledger",
+    },
+    {
+      id: "seam-stamp",
+      file: path.join(root, "motion-doctrine", "scripts", "seam-stamp.mjs"),
+      why: "stamps ledger rows onto the master timeline",
+    },
+    {
+      id: "storyboard-format",
+      file: path.join(root, "hyperframes-core", "references", "storyboard-format.md"),
+      why: "the STORYBOARD.md contract brag compiles into",
+    },
+    {
+      id: "frame-worker-core",
+      file: path.join(root, "hyperframes-core", "references", "frame-worker-core.md"),
+      why: "the frame-worker role contract brag's delta extends",
+    },
+  ];
+}
+
+export const animationDir = (root = requireSkillsRoot()) =>
+  path.join(root, "hyperframes-animation");
+
+export const seamGateScript = (root = requireSkillsRoot()) =>
+  path.join(root, "motion-doctrine", "scripts", "seam-gate.mjs");
+
+export const seamStampScript = (root = requireSkillsRoot()) =>
+  path.join(root, "motion-doctrine", "scripts", "seam-stamp.mjs");
+
+/* ------------------------------------------------------------------ vocabulary */
+
+/**
+ * Motion rule ids, read through HyperFrames' own parser so brag can never
+ * disagree with the frame-worker packet builder about what exists.
+ */
+export async function ruleIds() {
+  const root = requireSkillsRoot();
+  const core = path.join(root, "hyperframes-core", "scripts", "lib", "frame-packets-core.mjs");
+  const mod = await import(`file://${core.split(path.sep).join("/")}`);
+  if (typeof mod.knownRuleIds !== "function") {
+    throw envError(
+      `${core} no longer exports knownRuleIds(). HyperFrames changed shape; brag's bridge needs updating.`,
+    );
+  }
+  return new Set(mod.knownRuleIds(animationDir(root)));
+}
+
+/**
+ * Blueprint ids, parsed from the `<blueprints>` block. Entries are
+ * `<blueprint id="..." roles="..." duration="...">`, so the id is an attribute
+ * rather than the tag name — unlike rules-index, where the tag *is* the id.
+ */
+export function blueprintIds(root = requireSkillsRoot()) {
+  const file = path.join(root, "hyperframes-animation", "blueprints-index.md");
+  const text = fs.readFileSync(file, "utf8");
+  const block = text.match(/<blueprints>([\s\S]*?)<\/blueprints>/);
+  const scope = block ? block[1] : text;
+  return new Set([...scope.matchAll(/<blueprint\s+id="([^"]+)"/g)].map((m) => m[1]));
+}
+
+/**
+ * Blueprint id → the storyboard roles it is documented to serve. Used when a
+ * scene declares a narrative purpose and brag has to offer motion that fits it.
+ */
+export function blueprintRoles(root = requireSkillsRoot()) {
+  const file = path.join(root, "hyperframes-animation", "blueprints-index.md");
+  const text = fs.readFileSync(file, "utf8");
+  const out = new Map();
+  for (const m of text.matchAll(/<blueprint\s+id="([^"]+)"\s+roles="([^"]*)"/g)) {
+    out.set(
+      m[1],
+      m[2]
+        .split(",")
+        .map((r) => r.trim())
+        .filter(Boolean),
+    );
+  }
+  return out;
+}
+
+/**
+ * Tier-B transition names, read from the JSON block the injector itself reads.
+ * A seam that names anything else will not survive stamping.
+ */
+export function transitionNames(root = requireSkillsRoot()) {
+  const file = path.join(root, "hyperframes-animation", "transitions", "TRANSITION-REGISTRY.md");
+  const text = fs.readFileSync(file, "utf8");
+  const names = new Set();
+  for (const fence of text.matchAll(/```json\s*([\s\S]*?)```/g)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(fence[1]);
+    } catch {
+      continue;
+    }
+    const collect = (node) => {
+      if (Array.isArray(node)) return node.forEach(collect);
+      if (node && typeof node === "object") {
+        if (typeof node.name === "string") names.add(node.name);
+        Object.values(node).forEach(collect);
+      }
+    };
+    collect(parsed);
+  }
+  return names;
+}
+
+/* ------------------------------------------------------------------ shelling out */
+
+function which(cmd) {
+  const probe = spawnSync(process.platform === "win32" ? "where" : "which", [cmd], {
+    encoding: "utf8",
+  });
+  return probe.status === 0 ? probe.stdout.trim().split(/\r?\n/)[0] : null;
+}
+
+export function ffmpegAvailable() {
+  return Boolean(which("ffmpeg"));
+}
+
+export function ffprobeAvailable() {
+  return Boolean(which("ffprobe"));
+}
+
+/** Pinned HyperFrames invocation, so a project re-renders identically later. */
+export const HYPERFRAMES_PIN = process.env.BRAG_HYPERFRAMES_PIN ?? "hyperframes@0.7.88";
+
+export function hyperframesVersion() {
+  try {
+    return execFileSync("npx", ["--yes", HYPERFRAMES_PIN, "--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 180_000,
+      shell: process.platform === "win32",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run a HyperFrames subcommand in `cwd`.
+ * @returns {{status: number, stdout: string, stderr: string}}
+ */
+export function hyperframes(args, { cwd, timeout = 900_000, inherit = false } = {}) {
+  const res = spawnSync("npx", ["--yes", HYPERFRAMES_PIN, ...args], {
+    cwd,
+    encoding: "utf8",
+    timeout,
+    stdio: inherit ? "inherit" : ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
+  return {
+    status: res.status ?? 1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+/**
+ * Locate a Chrome the seam gate can drive.
+ *
+ * The gate finds Chrome itself on most machines but fails hard with
+ * "no Chrome found (set CHROME_PATH)" when the only browsers present are the
+ * ones HyperFrames and puppeteer downloaded into their own caches — which is
+ * the normal state of a machine that has only ever rendered through the CLI.
+ */
+export function chromePath() {
+  if (process.env.CHROME_PATH && exists(process.env.CHROME_PATH)) return process.env.CHROME_PATH;
+
+  const home = os.homedir();
+  const roots = [
+    path.join(home, ".cache", "puppeteer", "chrome"),
+    path.join(home, ".cache", "hyperframes", "chrome"),
+    path.join(home, ".cache", "puppeteer", "chrome-headless-shell"),
+  ];
+  const names = new Set(["chrome.exe", "chrome", "chrome-headless-shell.exe", "chrome-headless-shell"]);
+
+  const search = (dir, depth = 0) => {
+    if (depth > 4 || !exists(dir)) return null;
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => (a.name < b.name ? 1 : -1));
+    } catch {
+      return null;
+    }
+    for (const e of entries) {
+      const p = path.join(dir, e.name);
+      if (e.isFile() && names.has(e.name)) return p;
+      if (e.isDirectory()) {
+        const hit = search(p, depth + 1);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  };
+
+  for (const root of roots) {
+    const hit = search(root);
+    if (hit) return hit;
+  }
+
+  for (const p of [
+    "C:/Program Files/Google/Chrome/Application/chrome.exe",
+    "C:/Program Files (x86)/Google/Chrome/Application/chrome.exe",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/usr/bin/google-chrome",
+  ]) {
+    if (exists(p)) return p;
+  }
+  return null;
+}
+
+/**
+ * The seam gate spawns its own preview server, and that spawn is unreliable on
+ * repeated invocations: the same bytes verified once and then failed twice in a
+ * row with "HF runtime player never appeared". It is an infrastructure flake,
+ * not a finding about the composition, and treating it as one sent this build
+ * chasing a scene-id rule that did not exist.
+ *
+ * So exactly this message is retried, and nothing else. Any real seam failure
+ * still fails on the first attempt.
+ */
+const FLAKE = /runtime player never appeared/i;
+
+function runSeamGate({ cwd, ledger }) {
+  const chrome = chromePath();
+  const res = spawnSync(
+    process.execPath,
+    [seamGateScript(), "verify", "--ledger", ledger, "--project", "."],
+    {
+      cwd,
+      encoding: "utf8",
+      timeout: 300_000,
+      env: chrome ? { ...process.env, CHROME_PATH: chrome } : process.env,
+    },
+  );
+  return { status: res.status ?? 1, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+const pause = (ms) => {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    /* deliberately blocking: this runs between two child processes */
+  }
+};
+
+/**
+ * Reap orphaned HyperFrames preview servers.
+ *
+ * Every `check` and every gate run leaves one behind, and they accumulate
+ * until a new one cannot come up — which is what the "runtime player never
+ * appeared" flake actually is. They are orphans of brag's own child processes,
+ * so brag cleans them up, but only once the flake has been seen and never as a
+ * matter of course: someone may be running a preview server on purpose.
+ */
+function reapPreviewServers() {
+  const self = new Set([String(process.pid), String(process.ppid)]);
+  let killed = 0;
+  try {
+    if (process.platform === "win32") {
+      const list = spawnSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-Command",
+          "Get-CimInstance Win32_Process -Filter \"Name='node.exe'\" | " +
+            "Where-Object { $_.CommandLine -like '*hyperframes*' } | " +
+            "Select-Object -ExpandProperty ProcessId",
+        ],
+        { encoding: "utf8", timeout: 30_000 },
+      );
+      const pids = String(list.stdout || "")
+        .split(/\r?\n/u)
+        .map((p) => p.trim())
+        .filter((p) => p && !self.has(p));
+      for (const pid of pids) {
+        const res = spawnSync("taskkill", ["/PID", pid, "/T", "/F"], { encoding: "utf8", timeout: 15_000 });
+        if (res.status === 0) killed++;
+      }
+    } else {
+      const res = spawnSync("pkill", ["-f", "hyperframes.*preview"], { encoding: "utf8", timeout: 15_000 });
+      if (res.status === 0) killed++;
+    }
+  } catch {
+    /* Best effort: failing to reap is not worth failing the build over. */
+  }
+  return killed;
+}
+
+/** Run motion-doctrine's seam gate over a composition directory. */
+export function verifySeams({ cwd, ledger = "ledger.json", attempts = 3 }) {
+  let result;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    result = runSeamGate({ cwd, ledger });
+    if (result.status === 0) return { ...result, attempts: attempt };
+    if (!FLAKE.test(result.stdout + result.stderr)) return { ...result, attempts: attempt };
+    if (attempt < attempts) {
+      const killed = reapPreviewServers();
+      if (killed) warn(`seam gate could not start; reaped ${killed} orphaned preview server(s) and retrying`);
+      pause(2500);
+    }
+  }
+  return {
+    ...result,
+    attempts,
+    stderr:
+      `${result.stderr}
+
+The seam gate could not start its preview server in ${attempts} attempts. ` +
+      "That is an environment problem rather than a fault in the composition; " +
+      "check for a stray preview server still holding a port.",
+  };
+}

--- a/cli/lib/inspect/scan.mjs
+++ b/cli/lib/inspect/scan.mjs
@@ -1,0 +1,305 @@
+/**
+ * Deterministic product scan.
+ *
+ * This half of inspection is code, not judgment: file signals, extracted
+ * strings with byte offsets, real git history, real palette values. The model
+ * is only asked for the things a scan genuinely cannot decide — who this is
+ * for, what problem it solves, which of the extracted strings actually matter.
+ *
+ * Every string this returns carries a source, because §8.4 has to be able to
+ * trace a rendered word back to a file.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { exists } from "../util.mjs";
+
+const SKIP_DIRS = new Set([
+  ".git", "node_modules", "dist", "build", ".next", "out", "target",
+  "__pycache__", ".venv", "venv", ".tox", "coverage", ".cache",
+  "brag", "brag-output", ".pytest_cache", ".mypy_cache", "vendor",
+]);
+
+const MAX_FILE_BYTES = 512 * 1024;
+
+/* ------------------------------------------------------------------ walking */
+
+function walk(root, { maxDepth = 6 } = {}) {
+  const files = [];
+  const stack = [{ dir: root, rel: "", depth: 0 }];
+  while (stack.length) {
+    const { dir, rel, depth } = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      /* Dot-directories are skipped except the few that describe the project
+         rather than the machine it was checked out on. */
+      if (e.name.startsWith(".") && ![".github", ".claude-plugin"].includes(e.name)) continue;
+      if (SKIP_DIRS.has(e.name)) continue;
+      const abs = path.join(dir, e.name);
+      const r = rel ? `${rel}/${e.name}` : e.name;
+      if (e.isDirectory()) {
+        if (depth < maxDepth) stack.push({ dir: abs, rel: r, depth: depth + 1 });
+      } else if (e.isFile()) {
+        files.push(r);
+      }
+    }
+  }
+  return files.sort();
+}
+
+const readIf = (root, rel) => {
+  const abs = path.join(root, rel);
+  if (!exists(abs)) return null;
+  try {
+    const stat = fs.statSync(abs);
+    if (stat.size > MAX_FILE_BYTES) return null;
+    return fs.readFileSync(abs, "utf8");
+  } catch {
+    return null;
+  }
+};
+
+const parseJsonIf = (root, rel) => {
+  const text = readIf(root, rel);
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+};
+
+/** Byte offset of `needle` in a file, so a claim can be traced exactly. */
+function locate(root, rel, needle) {
+  const text = readIf(root, rel);
+  if (!text) return { file: rel };
+  const idx = text.indexOf(needle);
+  if (idx < 0) return { file: rel };
+  return {
+    file: rel,
+    line: text.slice(0, idx).split("\n").length,
+    byte_start: Buffer.byteLength(text.slice(0, idx)),
+    byte_end: Buffer.byteLength(text.slice(0, idx + needle.length)),
+  };
+}
+
+/* ------------------------------------------------------------------ surface signals */
+
+/**
+ * Score each candidate surface from file evidence. Classification stays the
+ * model's call, but it has to argue against these numbers rather than guess.
+ */
+function surfaceSignals(root, files) {
+  const has = (re) => files.filter((f) => re.test(f));
+  const pkg = parseJsonIf(root, "package.json");
+  const pyproject = readIf(root, "pyproject.toml");
+  const cargo = readIf(root, "Cargo.toml");
+
+  const evidence = { cli: [], website: [], library: [], api: [], desktop: [], mobile: [], game: [], research: [] };
+  const note = (surface, why) => evidence[surface].push(why);
+
+  if (pkg?.bin) note("cli", `package.json declares bin: ${Object.keys(pkg.bin).join(", ")}`);
+  if (pkg?.main || pkg?.exports) note("library", "package.json declares an entry point for importers");
+  if (pyproject && /^\s*\[project\.scripts\]/m.test(pyproject)) note("cli", "pyproject declares [project.scripts]");
+  if (pyproject && /^\s*\[project\]/m.test(pyproject) && !/\[project\.scripts\]/.test(pyproject))
+    note("library", "pyproject declares a distributable package");
+  if (cargo && /\[\[bin\]\]/.test(cargo)) note("cli", "Cargo.toml declares [[bin]]");
+  if (cargo && /\[lib\]/.test(cargo)) note("library", "Cargo.toml declares [lib]");
+
+  const argparse = has(/\.(py|mjs|js|ts|go|rs)$/).filter((f) => {
+    const t = readIf(root, f);
+    return t && /(argparse|commander|yargs|click\.|cobra|clap::|parseArgs|ArgumentParser)/.test(t);
+  });
+  if (argparse.length) note("cli", `argument parsing in ${argparse.slice(0, 3).join(", ")}`);
+
+  const html = has(/(^|\/)(index|home)\.html$/i);
+  if (html.length) note("website", `${html.length} top-level HTML page(s)`);
+  if (has(/^(src\/)?(pages|app|routes)\//).length) note("website", "a routed page directory");
+  if (pkg?.dependencies?.next || pkg?.dependencies?.astro || pkg?.dependencies?.["@sveltejs/kit"])
+    note("website", "a site framework in dependencies");
+
+  const openapi = has(/(openapi|swagger)\.(ya?ml|json)$/i);
+  if (openapi.length) note("api", `an API description at ${openapi[0]}`);
+  if (has(/(routes?|endpoints?|controllers?)\//).length && !html.length)
+    note("api", "server route modules with no page directory");
+
+  if (has(/\.(swift|kt)$/).length || exists(path.join(root, "Info.plist")))
+    note("mobile", "platform-native mobile sources");
+  if (pkg?.dependencies?.electron || pkg?.devDependencies?.electron) note("desktop", "electron in dependencies");
+  if (has(/\.(unity|uasset|tscn|godot)$/).length) note("game", "game-engine assets");
+  if (has(/\.(tex|bib)$/).length || has(/^(paper|thesis)/i).length) note("research", "paper sources");
+
+  const scored = Object.entries(evidence)
+    .map(([surface, why]) => ({ surface, score: why.length, evidence: why }))
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  return { scored, best: scored[0]?.surface ?? null, ambiguous: scored.length > 1 && scored[0]?.score === scored[1]?.score };
+}
+
+/* ------------------------------------------------------------------ extraction */
+
+/** CSS custom properties — the project's palette, in its own words. */
+function extractPalette(root, files) {
+  const out = [];
+  for (const rel of files.filter((f) => /\.(css|scss)$/.test(f)).slice(0, 12)) {
+    const text = readIf(root, rel);
+    if (!text) continue;
+    for (const m of text.matchAll(/--([a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{3,8}|rgba?\([^)]*\)|hsla?\([^)]*\)|oklch\([^)]*\))/g)) {
+      out.push({ role: m[1], value: m[2], source: locate(root, rel, m[0]) });
+    }
+  }
+  const seen = new Set();
+  return out.filter((c) => (seen.has(c.role) ? false : (seen.add(c.role), true))).slice(0, 24);
+}
+
+function extractFonts(root, files) {
+  const fonts = new Set();
+  for (const rel of files.filter((f) => /\.(css|scss|html)$/.test(f)).slice(0, 12)) {
+    const text = readIf(root, rel);
+    if (!text) continue;
+    for (const m of text.matchAll(/font-family\s*:\s*([^;]+);/g)) fonts.add(m[1].trim());
+    for (const m of text.matchAll(/fonts\.googleapis\.com\/css2?\?family=([^"'&]+)/g))
+      fonts.add(decodeURIComponent(m[1]).replace(/\+/g, " "));
+  }
+  return [...fonts].slice(0, 8);
+}
+
+/**
+ * Fenced code blocks in the README — usually the real commands.
+ *
+ * Every pattern here tolerates CRLF. Checked-out files on Windows routinely
+ * have it, and a `\n`-only fence pattern silently finds zero code blocks,
+ * which reads as "this project documents no commands" rather than as a bug.
+ * Offsets are still computed against the raw bytes, so nothing is normalised.
+ */
+function extractReadmeBlocks(root) {
+  const readme = ["README.md", "readme.md", "Readme.md"].find((f) => exists(path.join(root, f)));
+  if (!readme) return { file: null, headings: [], blocks: [], first_paragraph: null };
+  const text = readIf(root, readme) ?? "";
+
+  const headings = [...text.matchAll(/^(#{1,6})[ \t]+(.+?)[ \t]*$/gm)].map((m) => ({
+    level: m[1].length,
+    text: m[2].trim(),
+  }));
+
+  const blocks = [...text.matchAll(/```([a-zA-Z]*)[ \t]*\r?\n([\s\S]*?)```/g)]
+    .map((m) => ({ lang: m[1].toLowerCase() || null, body: m[2].replace(/\s+$/, "") }))
+    .filter((b) => b.body.length < 800)
+    .slice(0, 20);
+
+  /* The opening line often sits after a centred logo, a badge row, or a title,
+     so scan the whole document rather than only the pre-heading block. */
+  const firstPara = text
+    .split(/\r?\n\s*\r?\n/)
+    .map((p) => p.trim())
+    .find(
+      (p) =>
+        p.length > 40 &&
+        !p.startsWith("<") &&
+        !p.startsWith("#") &&
+        !p.startsWith("```") &&
+        !p.startsWith(">") &&
+        !p.startsWith("|") &&
+        !/^[[!]/.test(p) &&
+        !/^\s*[-*]\s/.test(p),
+    );
+
+  return { file: readme, headings: headings.slice(0, 30), blocks, first_paragraph: firstPara ?? null };
+}
+
+/** Command-shaped lines in README fences — candidates for a terminal tape. */
+function candidateCommands(root, readme) {
+  const cmds = [];
+  for (const block of readme.blocks) {
+    if (block.lang && !["bash", "sh", "shell", "console", "text", ""].includes(block.lang)) continue;
+    for (const raw of block.body.split(/\r?\n/)) {
+      const line = raw.replace(/^\s*\$\s?/, "").trim();
+      if (!line || line.startsWith("#") || line.length > 160) continue;
+      if (!/^[a-z][a-z0-9._-]*(\s|$)/i.test(line)) continue;
+      cmds.push({ command: line, source: locate(root, readme.file, raw.trim()) });
+    }
+  }
+  const seen = new Set();
+  return cmds.filter((c) => (seen.has(c.command) ? false : (seen.add(c.command), true))).slice(0, 24);
+}
+
+function gitInfo(root) {
+  const run = (args) => {
+    try {
+      return execFileSync("git", args, { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    } catch {
+      return null;
+    }
+  };
+  if (!run(["rev-parse", "--is-inside-work-tree"])) return null;
+  const log = run(["log", "--oneline", "-30", "--no-decorate"]) ?? "";
+  return {
+    url: run(["remote", "get-url", "origin"]),
+    default_branch: run(["rev-parse", "--abbrev-ref", "HEAD"]),
+    recent_commits: log
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => {
+        const [sha, ...rest] = l.split(" ");
+        return { sha, subject: rest.join(" ") };
+      }),
+  };
+}
+
+function findLogos(root, files) {
+  return files
+    .filter((f) => /(logo|icon|mark|wordmark)[^/]*\.(png|svg|jpg|jpeg|webp)$/i.test(f))
+    .slice(0, 6);
+}
+
+/* ------------------------------------------------------------------ entry point */
+
+/**
+ * @returns {object} signals — everything a scan can establish without judgment
+ */
+export function scanProduct(root) {
+  const files = walk(root);
+  const pkg = parseJsonIf(root, "package.json");
+  const readme = extractReadmeBlocks(root);
+  const surfaces = surfaceSignals(root, files);
+
+  const manifest =
+    pkg ??
+    (readIf(root, "pyproject.toml")
+      ? { _from: "pyproject.toml", raw: readIf(root, "pyproject.toml").slice(0, 4000) }
+      : null);
+
+  return {
+    scanned_at: new Date().toISOString(),
+    root: path.basename(root),
+    file_count: files.length,
+    surface: surfaces,
+    manifest: pkg
+      ? {
+          name: pkg.name,
+          version: pkg.version,
+          description: pkg.description,
+          bin: pkg.bin ? Object.keys(pkg.bin) : null,
+          license: pkg.license,
+          keywords: pkg.keywords ?? null,
+        }
+      : manifest,
+    readme,
+    candidate_commands: candidateCommands(root, readme),
+    palette: extractPalette(root, files),
+    fonts: extractFonts(root, files),
+    logos: findLogos(root, files),
+    docs: files.filter((f) => /^docs?\//.test(f)).slice(0, 40),
+    changelog: exists(path.join(root, "CHANGELOG.md")) ? "CHANGELOG.md" : null,
+    license: ["LICENSE", "LICENSE.md", "LICENCE"].find((f) => exists(path.join(root, f))) ?? null,
+    git: gitInfo(root),
+    top_level: files.filter((f) => !f.includes("/")).slice(0, 40),
+  };
+}

--- a/cli/lib/schema.mjs
+++ b/cli/lib/schema.mjs
@@ -1,0 +1,228 @@
+/**
+ * A small JSON Schema (2020-12 subset) validator.
+ *
+ * Why not ajv: this CLI ships inside a Claude Code plugin directory that is
+ * version-pinned and replaced wholesale on update, so an `npm install` step
+ * there is a reliability problem rather than a convenience. The subset below
+ * covers everything brag's schemas use, and validation errors have to be
+ * legible to a model that is about to rewrite the artifact — so the messages
+ * are the point, not the spec coverage.
+ *
+ * Supported: $ref (local, "#/$defs/..."), type, enum, const, required,
+ * properties, additionalProperties, patternProperties, items, prefixItems,
+ * minItems, maxItems, uniqueItems, minLength, maxLength, pattern, minimum,
+ * maximum, exclusiveMinimum, exclusiveMaximum, multipleOf, allOf, anyOf,
+ * oneOf, not, nullable via type arrays, and format: date-time|uri|email.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { artifactError } from "./util.mjs";
+
+const TYPES = {
+  string: (v) => typeof v === "string",
+  number: (v) => typeof v === "number" && Number.isFinite(v),
+  integer: (v) => Number.isInteger(v),
+  boolean: (v) => typeof v === "boolean",
+  object: (v) => v !== null && typeof v === "object" && !Array.isArray(v),
+  array: (v) => Array.isArray(v),
+  null: (v) => v === null,
+};
+
+const FORMATS = {
+  "date-time": (v) => !Number.isNaN(Date.parse(v)),
+  uri: (v) => /^[a-z][a-z0-9+.-]*:/i.test(v),
+  email: (v) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(v),
+};
+
+const typeOf = (v) =>
+  v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
+
+function resolveRef(ref, root) {
+  if (!ref.startsWith("#")) {
+    throw new Error(`only local $ref is supported, got ${ref}`);
+  }
+  const parts = ref.slice(1).split("/").filter(Boolean);
+  let node = root;
+  for (const raw of parts) {
+    const key = raw.replace(/~1/g, "/").replace(/~0/g, "~");
+    node = node?.[key];
+    if (node === undefined) throw new Error(`unresolvable $ref: ${ref}`);
+  }
+  return node;
+}
+
+/**
+ * @returns {{ok: boolean, errors: {path: string, message: string}[]}}
+ */
+export function validate(schema, data, { root = schema } = {}) {
+  const errors = [];
+
+  const err = (instancePath, message) =>
+    errors.push({ path: instancePath || "(root)", message });
+
+  const check = (sch, value, at) => {
+    if (sch === true || sch === undefined) return;
+    if (sch === false) return err(at, "no value is permitted here");
+
+    if (sch.$ref) return check(resolveRef(sch.$ref, root), value, at);
+
+    if (sch.const !== undefined && JSON.stringify(value) !== JSON.stringify(sch.const)) {
+      return err(at, `must be ${JSON.stringify(sch.const)}`);
+    }
+
+    if (sch.enum && !sch.enum.some((e) => JSON.stringify(e) === JSON.stringify(value))) {
+      return err(at, `must be one of: ${sch.enum.map((e) => JSON.stringify(e)).join(", ")}`);
+    }
+
+    if (sch.type) {
+      const allowed = Array.isArray(sch.type) ? sch.type : [sch.type];
+      if (!allowed.some((t) => TYPES[t]?.(value))) {
+        return err(at, `must be ${allowed.join(" or ")}, got ${typeOf(value)}`);
+      }
+    }
+
+    for (const key of ["allOf"]) {
+      if (sch[key]) for (const sub of sch[key]) check(sub, value, at);
+    }
+
+    if (sch.anyOf || sch.oneOf) {
+      const branches = sch.anyOf ?? sch.oneOf;
+      const passing = branches.filter((sub) => validate(sub, value, { root }).ok);
+      if (passing.length === 0) {
+        err(at, `does not match any allowed shape (${branches.length} tried)`);
+      } else if (sch.oneOf && passing.length > 1) {
+        err(at, `is ambiguous: matches ${passing.length} shapes, must match exactly one`);
+      }
+    }
+
+    if (sch.not && validate(sch.not, value, { root }).ok) {
+      err(at, "matches a forbidden shape");
+    }
+
+    if (typeof value === "string") {
+      if (sch.minLength !== undefined && value.length < sch.minLength)
+        err(at, `must be at least ${sch.minLength} characters, got ${value.length}`);
+      if (sch.maxLength !== undefined && value.length > sch.maxLength)
+        err(at, `must be at most ${sch.maxLength} characters, got ${value.length}`);
+      if (sch.pattern && !new RegExp(sch.pattern, "u").test(value))
+        err(at, `must match ${sch.pattern}`);
+      if (sch.format && FORMATS[sch.format] && !FORMATS[sch.format](value))
+        err(at, `must be a valid ${sch.format}`);
+    }
+
+    if (typeof value === "number") {
+      if (sch.minimum !== undefined && value < sch.minimum)
+        err(at, `must be >= ${sch.minimum}, got ${value}`);
+      if (sch.maximum !== undefined && value > sch.maximum)
+        err(at, `must be <= ${sch.maximum}, got ${value}`);
+      if (sch.exclusiveMinimum !== undefined && value <= sch.exclusiveMinimum)
+        err(at, `must be > ${sch.exclusiveMinimum}, got ${value}`);
+      if (sch.exclusiveMaximum !== undefined && value >= sch.exclusiveMaximum)
+        err(at, `must be < ${sch.exclusiveMaximum}, got ${value}`);
+      if (sch.multipleOf !== undefined && Math.abs(value / sch.multipleOf % 1) > 1e-9)
+        err(at, `must be a multiple of ${sch.multipleOf}`);
+    }
+
+    if (Array.isArray(value)) {
+      if (sch.minItems !== undefined && value.length < sch.minItems)
+        err(at, `needs at least ${sch.minItems} items, got ${value.length}`);
+      if (sch.maxItems !== undefined && value.length > sch.maxItems)
+        err(at, `allows at most ${sch.maxItems} items, got ${value.length}`);
+      if (sch.uniqueItems) {
+        const seen = new Set();
+        value.forEach((v, i) => {
+          const k = JSON.stringify(v);
+          if (seen.has(k)) err(`${at}[${i}]`, "is a duplicate; items must be unique");
+          seen.add(k);
+        });
+      }
+      (sch.prefixItems ?? []).forEach((sub, i) => {
+        if (i < value.length) check(sub, value[i], `${at}[${i}]`);
+      });
+      if (sch.items) {
+        const from = sch.prefixItems?.length ?? 0;
+        for (let i = from; i < value.length; i++) check(sch.items, value[i], `${at}[${i}]`);
+      }
+    }
+
+    if (TYPES.object(value)) {
+      for (const key of sch.required ?? []) {
+        if (!(key in value)) err(at, `is missing required property "${key}"`);
+      }
+      const props = sch.properties ?? {};
+      for (const [key, sub] of Object.entries(props)) {
+        if (key in value) check(sub, value[key], at ? `${at}.${key}` : key);
+      }
+      const patterns = Object.entries(sch.patternProperties ?? {});
+      for (const [key, v] of Object.entries(value)) {
+        for (const [pat, sub] of patterns) {
+          if (new RegExp(pat, "u").test(key)) check(sub, v, at ? `${at}.${key}` : key);
+        }
+      }
+      if (sch.additionalProperties === false) {
+        const known = new Set(Object.keys(props));
+        for (const key of Object.keys(value)) {
+          if (known.has(key)) continue;
+          if (patterns.some(([pat]) => new RegExp(pat, "u").test(key))) continue;
+          err(at ? `${at}.${key}` : key, `is not a recognised property`);
+        }
+      } else if (TYPES.object(sch.additionalProperties)) {
+        const known = new Set(Object.keys(props));
+        for (const [key, v] of Object.entries(value)) {
+          if (!known.has(key)) check(sch.additionalProperties, v, at ? `${at}.${key}` : key);
+        }
+      }
+    }
+  };
+
+  check(schema, data, "");
+  return { ok: errors.length === 0, errors };
+}
+
+/* ------------------------------------------------------------------ registry */
+
+const cache = new Map();
+
+/** Absolute path to the repo's schemas/ directory. */
+export function schemaDir(repoRoot) {
+  return path.join(repoRoot, "schemas");
+}
+
+export function loadSchema(repoRoot, name) {
+  const key = `${repoRoot}::${name}`;
+  if (cache.has(key)) return cache.get(key);
+  const file = path.join(schemaDir(repoRoot), `${name}.schema.json`);
+  if (!fs.existsSync(file)) {
+    throw artifactError(`no schema named "${name}" (looked in ${file})`);
+  }
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  cache.set(key, parsed);
+  return parsed;
+}
+
+export function listSchemas(repoRoot) {
+  const dir = schemaDir(repoRoot);
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".schema.json"))
+    .map((f) => f.replace(/\.schema\.json$/, ""))
+    .sort();
+}
+
+/**
+ * Validate `data` against a named schema, throwing a BragError whose message
+ * is directly actionable by whoever produced the artifact.
+ */
+export function assertValid(repoRoot, name, data, { source = "artifact" } = {}) {
+  const schema = loadSchema(repoRoot, name);
+  const { ok, errors } = validate(schema, data);
+  if (ok) return data;
+  const lines = errors.slice(0, 20).map((e) => `  ${e.path} ${e.message}`);
+  if (errors.length > 20) lines.push(`  … and ${errors.length - 20} more`);
+  throw artifactError(
+    `${source} does not satisfy the "${name}" schema:\n${lines.join("\n")}`,
+    { schema: name, errors },
+  );
+}

--- a/cli/lib/score/concept.mjs
+++ b/cli/lib/score/concept.mjs
@@ -1,0 +1,167 @@
+/**
+ * Concept distinctness and selection.
+ *
+ * Two things here are deliberately code rather than judgment.
+ *
+ * Distinctness: asked for three different concepts, a model will happily
+ * produce three descriptions of the same film. Overlap is measured on the
+ * words that carry the idea — metaphor, visual rule, premise — and a set that
+ * is really one concept in three costumes is rejected before anyone scores it.
+ *
+ * Novelty and difference-from-previous: the model that wrote the concepts does
+ * not get to rate them on originality. Those two numbers are computed, and the
+ * CLI adds up the weighted total and picks. The model rates only what it can
+ * legitimately judge, in a separate pass from generation.
+ */
+
+const STOP = new Set(
+  ("a an and are as at be been but by for from has have how in into is it its of on or that the " +
+    "their them then there these they this to was were what when where which who will with you your " +
+    "video film scene shows show viewer product user")
+    .split(" "),
+);
+
+/** Content words that actually carry a concept's idea. */
+function ideaTokens(concept) {
+  const text = [
+    concept.central_metaphor,
+    concept.visual_rule,
+    concept.premise,
+    concept.emotional_arc,
+    ...(concept.forbidden_motifs ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return new Set(
+    text
+      .replace(/[^a-z0-9\s-]/g, " ")
+      .split(/\s+/)
+      .filter((w) => w.length > 2 && !STOP.has(w)),
+  );
+}
+
+function overlap(a, b) {
+  const ta = ideaTokens(a);
+  const tb = ideaTokens(b);
+  if (!ta.size || !tb.size) return 0;
+  let shared = 0;
+  for (const t of ta) if (tb.has(t)) shared++;
+  return Number((shared / Math.min(ta.size, tb.size)).toFixed(3));
+}
+
+/** Above this, two concepts are the same idea wearing different words. */
+export const DISTINCTNESS_CEILING = 0.5;
+
+/**
+ * @returns {{ok:boolean, pairs:{a:string,b:string,overlap:number}[]}}
+ */
+export function checkDistinct(concepts, { ceiling = DISTINCTNESS_CEILING } = {}) {
+  const pairs = [];
+  for (let i = 0; i < concepts.length; i++) {
+    for (let j = i + 1; j < concepts.length; j++) {
+      const score = overlap(concepts[i], concepts[j]);
+      if (score >= ceiling) {
+        pairs.push({ a: concepts[i].id, b: concepts[j].id, overlap: score });
+      }
+    }
+  }
+  return { ok: pairs.length === 0, pairs };
+}
+
+/**
+ * How unlike the rest of its own batch a concept is. Rewards the one that is
+ * not a variation on the others.
+ */
+export function novelty(concept, all) {
+  const others = all.filter((c) => c.id !== concept.id);
+  if (!others.length) return 5;
+  const worst = Math.max(...others.map((o) => overlap(concept, o)));
+  return Number((5 * (1 - worst)).toFixed(2));
+}
+
+/**
+ * How unlike the videos already made this concept is. Compared against the
+ * worlds and motifs of past deliveries, not their copy.
+ */
+export function differenceFromPrevious(concept, history = []) {
+  if (!history.length) return 5;
+  const mine = new Set([
+    concept.suggested_world,
+    ...ideaTokens(concept),
+  ].filter(Boolean));
+
+  let worst = 0;
+  for (const prior of history) {
+    const theirs = new Set(
+      [prior.world, ...(prior.object_motifs ?? []), ...(prior.dominant_layouts ?? []).map((l) => l.id)].filter(Boolean),
+    );
+    if (!theirs.size) continue;
+    let shared = 0;
+    for (const t of theirs) if (mine.has(t)) shared++;
+    worst = Math.max(worst, shared / theirs.size);
+  }
+  return Number((5 * (1 - worst)).toFixed(2));
+}
+
+/**
+ * Weights. Clarity and proof dominate because a beautiful video that leaves a
+ * viewer unsure what the product does has failed at the only job it had.
+ */
+export const WEIGHTS = {
+  product_clarity: 3,
+  product_proof: 2.5,
+  silent_comprehension: 2,
+  emotional_strength: 1.5,
+  platform_fit: 1,
+  novelty: 2,
+  difference_from_previous: 1.5,
+};
+
+/**
+ * Score every concept and rank them. The CLI decides; the model only supplies
+ * the ratings it is entitled to.
+ *
+ * @returns {{ranked: object[], winner: object}}
+ */
+export function rankConcepts({ concepts, scores, history = [] }) {
+  const byId = new Map(scores.map((s) => [s.concept_id, s.criteria]));
+
+  const ranked = concepts
+    .map((concept) => {
+      const rated = byId.get(concept.id);
+      if (!rated) {
+        throw new Error(`concept "${concept.id}" was not scored`);
+      }
+      const computed = {
+        novelty: novelty(concept, concepts),
+        difference_from_previous: differenceFromPrevious(concept, history),
+      };
+
+      let total = 0;
+      for (const [key, weight] of Object.entries(WEIGHTS)) {
+        const value = key in computed ? computed[key] : rated[key]?.score;
+        if (typeof value !== "number") throw new Error(`concept "${concept.id}" is missing "${key}"`);
+        total += value * weight;
+      }
+
+      return {
+        concept,
+        rated: Object.fromEntries(Object.entries(rated).map(([k, v]) => [k, v.score])),
+        justifications: Object.fromEntries(Object.entries(rated).map(([k, v]) => [k, v.because])),
+        computed,
+        total: Number(total.toFixed(2)),
+      };
+    })
+    /* Ties break toward clarity, then toward the concept that is least like
+       anything already made. */
+    .sort(
+      (a, b) =>
+        b.total - a.total ||
+        b.rated.product_clarity - a.rated.product_clarity ||
+        b.computed.difference_from_previous - a.computed.difference_from_previous,
+    );
+
+  return { ranked, winner: ranked[0] };
+}

--- a/cli/lib/score/fingerprint.mjs
+++ b/cli/lib/score/fingerprint.mjs
@@ -1,0 +1,204 @@
+/**
+ * Visual fingerprints and the anti-sameness gates.
+ *
+ * Adding templates to a system like this eventually produces more repetitive
+ * templates, so repetition is measured rather than hoped against. A fingerprint
+ * describes how a video is *made* — where content sits, how cuts travel, how
+ * deep the frame is — not what it says. Two videos about different products can
+ * still be the same video.
+ *
+ * The comparison is deliberately structural. Copy differs every time; that is
+ * exactly why copy must not be part of the signature.
+ */
+
+import { assignLayouts } from "../worlds.mjs";
+import { gateError } from "../util.mjs";
+
+/**
+ * @returns {object} fingerprint
+ */
+export function fingerprint({ graph, world }) {
+  const scenes = graph.scenes;
+  const assigned = assignLayouts(world, scenes, graph.seams ?? []);
+
+  /* A scene that inherited its layout because something is handed into it is
+     the same shot continuing, not the same shot again, so it does not count
+     against the overuse ceiling. Counting it would make declaring a carrier —
+     the strongest kind of continuity there is — look like repetition. */
+  const layoutCounts = {};
+  for (const a of assigned) {
+    if (a.carried) continue;
+    layoutCounts[a.layout.id] = (layoutCounts[a.layout.id] ?? 0) + 1;
+  }
+
+  const seams = graph.seams ?? [];
+  const families = new Set(
+    seams.map((s) => familyOf(s.technique)).filter(Boolean),
+  );
+
+  const anchors = new Set(assigned.map((a) => a.layout.anchor));
+  const aligns = new Set(assigned.map((a) => a.layout.align));
+
+  return {
+    schema: "brag.fingerprint/1",
+    world: world.id,
+    dominant_layouts: Object.entries(layoutCounts)
+      .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))
+      .map(([id, n]) => ({ id, scenes: n })),
+    transition_families: [...families].sort(),
+    camera_usage: world.camera_model,
+    depth_usage: world.depth_levels,
+    typography_mode: `${world.typography?.lead_family ?? "sans"}-${world.typography?.case ?? "sentence"}-${world.typography?.display_scale ?? 1}`,
+    object_motifs: [
+      ...new Set((graph.objects ?? []).map((o) => o.kind)),
+      ...new Set(assigned.map((a) => a.layout.chrome ?? "none")),
+    ].sort(),
+    composition_shape: [...anchors].sort().join("/") + "|" + [...aligns].sort().join("/"),
+    scene_count: scenes.length,
+    carrier_seams: seams.filter((s) => s.carrier).length,
+    transformation_scenes: scenes.filter(isTransformation).length,
+  };
+}
+
+/** Which transition family a technique belongs to. */
+export function familyOf(technique) {
+  if (!technique) return "cut";
+  const t = String(technique).toLowerCase();
+  if (t.includes("morph") || t.includes("match")) return "morph";
+  /* cut-the-curve is lateral partial travel, so it belongs with the slides
+     despite the name; only a change of depth counts as a zoom. */
+  if (t.includes("curve") || t.includes("slide") || t.includes("wipe")) return "slide";
+  if (t.includes("zoom") || t.includes("push") || t.includes("dolly")) return "zoom";
+  if (t.includes("mask") || t.includes("blind") || t.includes("reveal")) return "mask";
+  if (t.includes("dissolve") || t.includes("fade") || t.includes("crossfade")) return "dissolve";
+  if (t.includes("rotate") || t.includes("flip")) return "rotate";
+  return "cut";
+}
+
+/**
+ * A scene that transforms what is already on screen, rather than replacing it
+ * with the next thing. Objects that persist across a scene boundary and change
+ * state are the cheapest honest signal of this.
+ */
+function isTransformation(scene) {
+  return (scene.objects ?? []).some(
+    (o) => o.start_state && o.end_state && o.start_state !== o.end_state,
+  );
+}
+
+/* ------------------------------------------------------------------ similarity */
+
+const tokens = (fp) =>
+  new Set([
+    `world:${fp.world}`,
+    `camera:${fp.camera_usage}`,
+    `depth:${fp.depth_usage}`,
+    `type:${fp.typography_mode}`,
+    `shape:${fp.composition_shape}`,
+    ...fp.dominant_layouts.map((l) => `layout:${l.id}`),
+    ...fp.transition_families.map((f) => `family:${f}`),
+    ...fp.object_motifs.map((m) => `motif:${m}`),
+  ]);
+
+/**
+ * Jaccard overlap of structural tokens, 0 (nothing shared) to 1 (identical).
+ */
+export function similarity(a, b) {
+  const ta = tokens(a);
+  const tb = tokens(b);
+  if (!ta.size && !tb.size) return 1;
+  let shared = 0;
+  for (const t of ta) if (tb.has(t)) shared++;
+  const union = ta.size + tb.size - shared;
+  return union === 0 ? 1 : Number((shared / union).toFixed(3));
+}
+
+/* ------------------------------------------------------------------ gates */
+
+export const SIMILARITY_CEILING = 0.45;
+const LAYOUT_SHARE_CEILING = 0.4;
+
+/**
+ * @param {object} fp
+ * @param {object[]} history previous fingerprints, newest first
+ * @returns {{ok:boolean, violations:object[], nearest:object|null}}
+ */
+export function checkSameness(fp, history = []) {
+  const violations = [];
+
+  /* 1. Not too close to something already made. */
+  let nearest = null;
+  for (const prior of history) {
+    const score = similarity(fp, prior);
+    if (!nearest || score > nearest.score) nearest = { score, world: prior.world };
+  }
+  if (nearest && nearest.score >= SIMILARITY_CEILING) {
+    violations.push({
+      code: "too_similar",
+      message:
+        `this is ${(nearest.score * 100).toFixed(0)}% the same construction as a recent video ` +
+        `(ceiling ${SIMILARITY_CEILING * 100}%, nearest used the "${nearest.world}" world)`,
+      fix: "choose a different visual world, or a concept that needs a different kind of frame",
+    });
+  }
+
+  /* 2. No single layout carries the film. */
+  const total = fp.dominant_layouts.reduce((n, l) => n + l.scenes, 0);
+  for (const layout of fp.dominant_layouts) {
+    const share = layout.scenes / total;
+    if (share > LAYOUT_SHARE_CEILING + 1e-9) {
+      violations.push({
+        code: "layout_overused",
+        message: `layout "${layout.id}" carries ${layout.scenes} of ${total} scenes (${(share * 100).toFixed(0)}%, ceiling ${LAYOUT_SHARE_CEILING * 100}%)`,
+        fix: "give some scenes a different composition, or pick a world with more layouts",
+      });
+    }
+  }
+
+  /* 3. More than one kind of cut.
+     The spec asks for three families; a film with two seams cannot spend
+     three, so the requirement is the smaller of three and the number of cuts
+     the film actually has. Demanding the impossible would just teach everyone
+     to switch the gate off. */
+  const seamCount = fp.transformation_scenes + fp.carrier_seams >= 0 ? fp.scene_count - 1 : 0;
+  const required = Math.min(3, Math.max(1, seamCount));
+  if (fp.transition_families.length < required) {
+    violations.push({
+      code: "one_note_transitions",
+      message: `${fp.transition_families.length} transition family (${fp.transition_families.join(", ") || "none"}) across ${seamCount} cuts; wanted ${required}`,
+      fix: "vary how the cuts travel — a film with one move in it reads as a slideshow",
+    });
+  }
+
+  /* 4 and 5 are reported, not enforced, until the scene graph routinely
+     carries object states and carriers. Enforcing them now would fail every
+     honest outline before the frame workers exist to satisfy them. */
+  const advisories = [];
+  if (fp.transformation_scenes === 0) {
+    advisories.push({
+      code: "no_transformation",
+      message: "every scene replaces the last rather than transforming it",
+      fix: "give at least one object a start and end state that differ",
+    });
+  }
+  if (fp.carrier_seams === 0) {
+    advisories.push({
+      code: "no_carrier",
+      message: "no cut is driven by a product element crossing it",
+      fix: "hand something concrete across a seam — a cursor, a panel, a value",
+    });
+  }
+
+  return { ok: violations.length === 0, violations, advisories, nearest };
+}
+
+export function assertSameness(fp, history) {
+  const result = checkSameness(fp, history);
+  if (!result.ok) {
+    throw gateError(
+      "this video is too much like the ones before it:\n" +
+        result.violations.map((v) => `  - ${v.message}\n    fix: ${v.fix}`).join("\n"),
+    );
+  }
+  return result;
+}

--- a/cli/lib/solve/timing.mjs
+++ b/cli/lib/solve/timing.mjs
@@ -1,0 +1,259 @@
+/**
+ * The timing solver.
+ *
+ * Timing conflicts are the most common way a video becomes unreadable, and
+ * prose cannot resolve them: "hold long enough to read, but keep the pace, and
+ * land on the beat" is three constraints that routinely disagree. So they are
+ * stated as numbers and solved.
+ *
+ * Per scene:
+ *   entry      the entrance animation, before anything is settled
+ *   reading    every line that must be read, each with its own floor
+ *   dwell      comprehension time for non-text content
+ *   exit       the outgoing half of the seam
+ *   max        the ceiling this scene must not exceed
+ *
+ * When the constraints cannot all hold, the solver relaxes in a fixed order,
+ * which is the audio hierarchy from the spec read as a priority list:
+ *
+ *   1. reading clarity        never relaxed — copy that cannot be read is a bug
+ *   2. narrative timing       scene order and proof placement, never relaxed
+ *   3. visual comprehension   dwell can shrink to zero
+ *   4. strong cue locks       a scene may leave its musical cue
+ *   5. minor beat alignment   dropped first
+ *
+ * If it still does not fit, the solver refuses. Silently truncating a line is
+ * how a video ends up with copy nobody can read.
+ */
+
+import { readingFloor } from "../compile/targets.mjs";
+
+const ENTRY = 0.4;
+const STAGGER = 0.45;
+const EXIT = 0.34;
+const CUE_TOLERANCE = 0.15;
+const BEAT_TOLERANCE = 0.1;
+
+/** The smallest a scene can be and still show what it promises. */
+export function minimumDuration(scene) {
+  const lines = scene.reading ?? [];
+  const floors = lines.map((r) => r.min_reading_s ?? readingFloor(r.text));
+
+  /* Lines arrive staggered; the last one still needs its whole floor. */
+  const copy = floors.length
+    ? ENTRY + STAGGER * (floors.length - 1) + floors[floors.length - 1]
+    : ENTRY;
+
+  const dwell = scene.dwell_s ?? 0;
+  return Number((Math.max(copy, ENTRY + dwell) + EXIT).toFixed(2));
+}
+
+/**
+ * How long a scene may run past the point where its last line is readable.
+ * A held frame is fine; a held frame with nothing left to give is a dead shot,
+ * and doctrine treats a scene that finishes entering with seconds to spare as
+ * a planning bug rather than a pause.
+ */
+const HOLD_SLACK = 0.8;
+
+/**
+ * What the scene would like, given room — bounded by what its content can
+ * actually fill. A declared duration longer than that is trimmed, because the
+ * alternative is a frozen shot that the motion sidecar will fail anyway.
+ */
+export function preferredDuration(scene) {
+  const min = minimumDuration(scene);
+  const declared = scene.duration ?? min;
+  const ceiling = Number((min + HOLD_SLACK + (scene.dwell_s ?? 0)).toFixed(2));
+  return Number(Math.max(min, Math.min(declared, ceiling)).toFixed(2));
+}
+
+/** Scenes whose declared duration outruns what they have to show. */
+export function overlongScenes(graph) {
+  return graph.scenes
+    .map((scene) => ({
+      scene,
+      declared: scene.duration ?? 0,
+      supported: preferredDuration(scene),
+    }))
+    .filter((r) => r.declared - r.supported > 0.05);
+}
+
+const nearest = (value, candidates) =>
+  candidates.length
+    ? candidates.reduce((best, c) => (Math.abs(c - value) < Math.abs(best - value) ? c : best))
+    : null;
+
+/**
+ * Solve scene starts and durations.
+ *
+ * @param {object} graph
+ * @param {object} [opts]
+ * @param {number[]} [opts.strongCues]  seconds
+ * @param {number[]} [opts.beats]       seconds
+ * @param {number} [opts.targetDuration] total the edit is aiming at
+ * @returns {{ok, scenes, total, relaxations, violations}}
+ */
+export function solveTiming(graph, { strongCues = [], beats = [], targetDuration = null } = {}) {
+  const relaxations = [];
+  const violations = [];
+
+  for (const { scene, declared, supported } of overlongScenes(graph)) {
+    relaxations.push({
+      level: 3,
+      kind: "scene_trimmed",
+      scene: scene.id,
+      message:
+        `trimmed "${scene.id}" from ${declared}s to ${supported}s: it has ` +
+        `${(scene.reading ?? []).length || 1} line(s) to show and the rest would be a held frame`,
+    });
+  }
+
+  const scenes = graph.scenes.map((scene) => {
+    const min = minimumDuration(scene);
+    const preferred = preferredDuration(scene);
+    const max = scene.max_duration_s ?? Math.max(preferred, min);
+    if (max < min) {
+      violations.push({
+        scene: scene.id,
+        kind: "impossible_ceiling",
+        message:
+          `scene "${scene.id}" caps at ${max}s but needs ${min}s to show its copy ` +
+          `(${(scene.reading ?? []).length} line(s)). Cut a line or raise the ceiling.`,
+        needs: min,
+        has: max,
+      });
+    }
+    return { id: scene.id, min, preferred, max: Math.max(max, min), duration: preferred, start: 0 };
+  });
+
+  /* Fit the total, if one was asked for. Reading floors are never touched, so
+     the only slack is the gap between preferred and minimum. */
+  if (targetDuration) {
+    const preferredTotal = scenes.reduce((n, s) => n + s.preferred, 0);
+    const minTotal = scenes.reduce((n, s) => n + s.min, 0);
+
+    if (preferredTotal > targetDuration) {
+      if (minTotal > targetDuration) {
+        violations.push({
+          kind: "target_too_short",
+          message:
+            `the edit targets ${targetDuration}s but its copy needs ${minTotal.toFixed(2)}s ` +
+            `at the reading floor. Cut a scene or cut copy — the floor does not move.`,
+          needs: Number(minTotal.toFixed(2)),
+          has: targetDuration,
+        });
+      } else {
+        /* Squeeze proportionally into the slack above each minimum. */
+        const slack = preferredTotal - minTotal;
+        const overflow = preferredTotal - targetDuration;
+        for (const s of scenes) {
+          const share = slack > 0 ? (s.preferred - s.min) / slack : 0;
+          s.duration = Number(Math.max(s.min, s.preferred - overflow * share).toFixed(2));
+        }
+        relaxations.push({
+          level: 3,
+          kind: "comprehension_dwell",
+          message: `tightened ${overflow.toFixed(2)}s of dwell to reach ${targetDuration}s; no reading floor was touched`,
+        });
+      }
+    }
+  }
+
+  /* Lay scenes end to end. */
+  let t = 0;
+  for (const s of scenes) {
+    s.start = Number(t.toFixed(3));
+    t += s.duration;
+  }
+
+  /* Now try to land cuts on the music, in priority order: a strong cue may
+     move a cut by up to 0.15s, a plain beat by 0.10s, and neither may push a
+     scene below its minimum. */
+  const cutLocks = [];
+  for (let i = 1; i < scenes.length; i++) {
+    const cut = scenes[i].start;
+    const cue = nearest(cut, strongCues);
+    const beat = nearest(cut, beats);
+
+    let target = null;
+    let level = null;
+    if (cue !== null && Math.abs(cue - cut) <= CUE_TOLERANCE) {
+      target = cue;
+      level = "strong_cue";
+    } else if (beat !== null && Math.abs(beat - cut) <= BEAT_TOLERANCE) {
+      target = beat;
+      level = "beat";
+    }
+    if (target === null) continue;
+
+    const delta = Number((target - cut).toFixed(3));
+    const prev = scenes[i - 1];
+    const grown = Number((prev.duration + delta).toFixed(3));
+
+    if (grown < prev.min) {
+      relaxations.push({
+        level: 4,
+        kind: "cue_dropped",
+        scene: prev.id,
+        message:
+          `left the ${level} at ${target}s: honouring it would cut "${prev.id}" to ${grown}s, ` +
+          `below its ${prev.min}s reading floor`,
+      });
+      continue;
+    }
+
+    prev.duration = grown;
+    for (let j = i; j < scenes.length; j++) {
+      scenes[j].start = Number((scenes[j].start + delta).toFixed(3));
+    }
+    cutLocks.push({ at: target, kind: level, between: [prev.id, scenes[i].id] });
+  }
+
+  /* At most three strong-cue locks: more than that and the edit is following
+     the music instead of the story. */
+  const strong = cutLocks.filter((l) => l.kind === "strong_cue");
+  if (strong.length > 3) {
+    relaxations.push({
+      level: 5,
+      kind: "cue_budget",
+      message: `${strong.length} strong-cue locks exceeds the budget of 3; keeping the first three`,
+    });
+    for (const extra of strong.slice(3)) extra.kind = "beat";
+  }
+
+  const total = Number(scenes.reduce((max, s) => Math.max(max, s.start + s.duration), 0).toFixed(3));
+
+  return {
+    ok: violations.length === 0,
+    scenes: scenes.map((s) => ({
+      id: s.id,
+      start: s.start,
+      duration: Number(s.duration.toFixed(2)),
+      min: s.min,
+      preferred: s.preferred,
+      slack: Number((s.duration - s.min).toFixed(2)),
+    })),
+    total,
+    cut_locks: cutLocks,
+    relaxations,
+    violations,
+  };
+}
+
+/** Write the solve back into the graph so every later stage reads one answer. */
+export function applyTiming(graph, plan) {
+  const byId = new Map(plan.scenes.map((s) => [s.id, s]));
+  return {
+    ...graph,
+    duration: plan.total,
+    scenes: graph.scenes.map((scene) => {
+      const solved = byId.get(scene.id);
+      return solved ? { ...scene, start: solved.start, duration: solved.duration } : scene;
+    }),
+    seams: (graph.seams ?? []).map((seam) => {
+      const to = byId.get(seam.to);
+      return to ? { ...seam, at: to.start } : seam;
+    }),
+  };
+}

--- a/cli/lib/state.mjs
+++ b/cli/lib/state.mjs
@@ -1,0 +1,263 @@
+/**
+ * Project state: the `brag/` directory inside the target project, plus the
+ * cross-project memory in `~/.brag/`.
+ *
+ * Two rules hold this together:
+ *   1. Nothing mutable ever lives in the plugin directory — it is version
+ *      pinned and replaced wholesale on update.
+ *   2. A stage is complete when its artifact exists and validates. Never a
+ *      flag, never a log line. `brag status` is therefore just a directory
+ *      listing with opinions.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  artifactError,
+  ensureDir,
+  exists,
+  readJson,
+  writeJson,
+} from "./util.mjs";
+
+/** Repo root — three levels up from cli/lib/state.mjs. */
+export const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+/** Cross-project memory. Fingerprint history (§6) and the asset library (§12). */
+export const MEMORY_ROOT =
+  process.env.BRAG_HOME ?? path.join(os.homedir(), ".brag");
+
+/** The ten pipeline stages, in order. Each names the artifact that proves it. */
+export const STAGES = [
+  { id: "discover", command: "inspect", artifact: "product_model.json", schema: "product_model" },
+  { id: "position", command: "position", artifact: "positioning.json", schema: "positioning" },
+  { id: "concept", command: "select", artifact: "selected_concept.json", schema: "selected_concept" },
+  { id: "direct", command: "direct", artifact: "direction.json", schema: "direction" },
+  { id: "storyboard", command: "storyboard", artifact: "scene_graph.json", schema: "scene_graph" },
+  { id: "capture", command: "capture", artifact: "captures/capture_manifest.json", schema: "capture_manifest" },
+  { id: "compose", command: "compose", artifact: "compositions/index.json", schema: null },
+  { id: "review", command: "review", artifact: "reviews/latest.json", schema: "review_report" },
+  { id: "recompose", command: "variant", artifact: "compositions/index.json", schema: null },
+  { id: "deliver", command: "deliver", artifact: "delivery/manifest.json", schema: null },
+];
+
+export class Project {
+  /**
+   * @param {string} targetRoot directory of the product being bragged about
+   */
+  constructor(targetRoot) {
+    this.targetRoot = path.resolve(targetRoot);
+    this.dir = path.join(this.targetRoot, "brag");
+  }
+
+  /* ---------------------------------------------------------------- paths */
+
+  path(...parts) {
+    return path.join(this.dir, ...parts);
+  }
+
+  get projectFile() {
+    return this.path("project.json");
+  }
+
+  get exists() {
+    return exists(this.projectFile);
+  }
+
+  /** Where a task spec is written for the agent to answer. */
+  specPath(name) {
+    return this.path("tasks", `${name}.task.md`);
+  }
+
+  /** Where the agent is told to write its answer. */
+  answerPath(name) {
+    return this.path("tasks", `${name}.json`);
+  }
+
+  /* ---------------------------------------------------------------- lifecycle */
+
+  init({ name, targetSurfaceHint = null, force = false }) {
+    if (this.exists && !force) {
+      throw artifactError(
+        `${this.dir} already exists. Use \`brag status\` to resume, or pass --force to start over.`,
+      );
+    }
+    ensureDir(this.dir);
+    for (const sub of [
+      "tasks",
+      "concepts",
+      "captures",
+      "product_assets",
+      "compositions",
+      "reviews",
+      "renders",
+      "delivery",
+    ]) {
+      ensureDir(this.path(sub));
+    }
+    const project = {
+      schema: "brag.project/1",
+      name,
+      created_at: new Date().toISOString(),
+      brag_version: readPackageVersion(),
+      target_root: ".",
+      surface_hint: targetSurfaceHint,
+      stages: {},
+    };
+    writeJson(this.projectFile, project);
+    this.writeGitignore();
+    return project;
+  }
+
+  /**
+   * `brag/` holds captures and renders — large, regenerable, and sometimes
+   * full of whatever the product printed. Default to keeping it out of git and
+   * let the user opt back in.
+   */
+  writeGitignore() {
+    const file = this.path(".gitignore");
+    if (exists(file)) return;
+    fs.writeFileSync(
+      file,
+      [
+        "# Brag working state. Regenerable from source; captures may contain",
+        "# whatever your product printed. Delete these lines to version it.",
+        "captures/",
+        "renders/",
+        "compositions/",
+        "delivery/",
+        "tasks/",
+        "",
+      ].join("\n"),
+    );
+  }
+
+  load() {
+    if (!this.exists) {
+      throw artifactError(
+        `no brag project in ${this.targetRoot}. Run \`brag init\` there first.`,
+      );
+    }
+    return readJson(this.projectFile);
+  }
+
+  update(patch) {
+    const project = this.load();
+    const next = { ...project, ...patch, updated_at: new Date().toISOString() };
+    writeJson(this.projectFile, next);
+    return next;
+  }
+
+  /* ---------------------------------------------------------------- artifacts */
+
+  read(rel, opts) {
+    return readJson(this.path(rel), opts);
+  }
+
+  write(rel, value) {
+    return writeJson(this.path(rel), value);
+  }
+
+  has(rel) {
+    return exists(this.path(rel));
+  }
+
+  /**
+   * Stage completion is derived, never stored: the artifact is on disk or the
+   * stage did not happen. Returns one row per stage, in pipeline order.
+   */
+  stageStatus() {
+    const seen = new Set();
+    return STAGES.filter((s) => {
+      if (seen.has(s.id)) return false;
+      seen.add(s.id);
+      return true;
+    }).map((stage) => ({
+      ...stage,
+      done: this.has(stage.artifact),
+      path: stage.artifact,
+    }));
+  }
+
+  /** The first stage whose artifact is missing — i.e. what to do next. */
+  nextStage() {
+    return this.stageStatus().find((s) => !s.done) ?? null;
+  }
+}
+
+/* ------------------------------------------------------------------ memory */
+
+export class Memory {
+  constructor(root = MEMORY_ROOT) {
+    this.root = root;
+  }
+
+  path(...parts) {
+    return path.join(this.root, ...parts);
+  }
+
+  get historyFile() {
+    return this.path("history.json");
+  }
+
+  history() {
+    return (
+      readJson(this.historyFile, { optional: true }) ?? {
+        schema: "brag.history/1",
+        videos: [],
+      }
+    );
+  }
+
+  /** Append a delivered video's fingerprint. Drives the §6 anti-sameness gate. */
+  appendVideo(entry) {
+    ensureDir(this.root);
+    const history = this.history();
+    history.videos = [...history.videos.filter((v) => v.id !== entry.id), entry]
+      .sort((a, b) => (a.delivered_at < b.delivered_at ? -1 : 1))
+      .slice(-100);
+    writeJson(this.historyFile, history);
+    return history;
+  }
+
+  /** Fingerprints of the N most recent videos, newest first. */
+  recentFingerprints(limit = 10, { project = null } = {}) {
+    return this.history()
+      .videos.filter((v) => !project || v.project === project)
+      .slice(-limit)
+      .reverse()
+      .map((v) => v.fingerprint)
+      .filter(Boolean);
+  }
+}
+
+/* ------------------------------------------------------------------ helpers */
+
+let cachedVersion = null;
+
+export function readPackageVersion() {
+  if (cachedVersion) return cachedVersion;
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"),
+    );
+    cachedVersion = pkg.version ?? "0.0.0";
+  } catch {
+    cachedVersion = "0.0.0";
+  }
+  return cachedVersion;
+}
+
+/**
+ * Resolve the target project directory. Defaults to cwd, which is the common
+ * case: the user is standing in the thing they want to brag about.
+ */
+export function resolveProject(flags = {}) {
+  return new Project(flags.project ?? process.cwd());
+}

--- a/cli/lib/state.mjs
+++ b/cli/lib/state.mjs
@@ -226,10 +226,18 @@ export class Memory {
     return history;
   }
 
-  /** Fingerprints of the N most recent videos, newest first. */
-  recentFingerprints(limit = 10, { project = null } = {}) {
+  /**
+   * Fingerprints of the N most recent videos, newest first.
+   *
+   * `exclude` drops earlier deliveries of one project's own variant. Rebuilding
+   * a film after fixing something in it is not the failure the sameness gate
+   * exists to catch — without this, the second compile of the same cut always
+   * reads as 100% identical to the first, which it is, and which is the point.
+   */
+  recentFingerprints(limit = 10, { project = null, exclude = null } = {}) {
     return this.history()
       .videos.filter((v) => !project || v.project === project)
+      .filter((v) => !exclude || !(v.project === exclude.project && v.variant === exclude.variant))
       .slice(-limit)
       .reverse()
       .map((v) => v.fingerprint)

--- a/cli/lib/stub.mjs
+++ b/cli/lib/stub.mjs
@@ -1,0 +1,18 @@
+/**
+ * Placeholder for pipeline stages that land in a later phase.
+ *
+ * A stub exits non-zero and names the phase that will implement it, so an
+ * unfinished stage can never be mistaken for a passing one.
+ */
+
+import { BragError, EXIT } from "./util.mjs";
+
+export function notYet(command, phase, whatItWillDo) {
+  return async function run() {
+    throw new BragError(
+      `\`brag ${command}\` lands in ${phase}: ${whatItWillDo}\n` +
+        `Run \`brag status\` to see which stages are available now.`,
+      EXIT.USAGE,
+    );
+  };
+}

--- a/cli/lib/taskspec.mjs
+++ b/cli/lib/taskspec.mjs
@@ -1,0 +1,159 @@
+/**
+ * The emit/accept contract.
+ *
+ * The CLI never asks a model to *do* something inline. It writes a task spec —
+ * instructions, the inlined JSON Schema, and the exact output path — then the
+ * agent writes JSON to that path, then the CLI validates and recomputes
+ * whatever it can compute itself. A stage's completion criterion is always the
+ * artifact existing on disk and validating, never a claim that it was done.
+ *
+ * This mirrors the DISPATCH/WAIT contract HyperFrames uses for frame workers.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { assertValid, loadSchema } from "./schema.mjs";
+import { REPO_ROOT } from "./state.mjs";
+import {
+  artifactError,
+  exists,
+  readJson,
+  writeFileAtomic,
+} from "./util.mjs";
+
+const REFERENCE_DIR = path.join(REPO_ROOT, "skills", "brag", "references");
+
+/**
+ * Inline a creative-doctrine reference so there is exactly one copy of each
+ * rule and the agent cannot skip reading it.
+ */
+export function reference(name) {
+  const file = path.join(REFERENCE_DIR, name.endsWith(".md") ? name : `${name}.md`);
+  if (!exists(file)) {
+    throw artifactError(`missing reference: ${file}`);
+  }
+  return fs.readFileSync(file, "utf8").trim();
+}
+
+const fence = (lang, body) => "```" + lang + "\n" + body + "\n```";
+
+/**
+ * Write a task spec for the agent.
+ *
+ * @param {object} o
+ * @param {import("./state.mjs").Project} o.project
+ * @param {string} o.name          task id, e.g. "product_model"
+ * @param {string} o.title
+ * @param {string} o.objective     one paragraph: what this artifact is for
+ * @param {string[]} o.instructions ordered, imperative
+ * @param {string} o.schemaName    schema the answer must satisfy
+ * @param {object} [o.context]     facts the CLI already established
+ * @param {string[]} [o.references] reference file names to inline verbatim
+ * @param {string[]} [o.rejects]   things that will fail validation, stated plainly
+ * @returns {{specPath: string, answerPath: string}}
+ */
+export function emitTaskSpec({
+  project,
+  name,
+  title,
+  objective,
+  instructions = [],
+  schemaName,
+  context = null,
+  references = [],
+  rejects = [],
+}) {
+  const specPath = project.specPath(name);
+  const answerPath = project.answerPath(name);
+  const schema = loadSchema(REPO_ROOT, schemaName);
+
+  const relAnswer = path.relative(project.targetRoot, answerPath).split(path.sep).join("/");
+
+  const parts = [
+    `# Task: ${title}`,
+    "",
+    objective.trim(),
+    "",
+    "## What to do",
+    "",
+    ...instructions.map((s, i) => `${i + 1}. ${s}`),
+    "",
+    "## Where the answer goes",
+    "",
+    `Write a single JSON document to \`${relAnswer}\`, then run the \`--accept\` form of`,
+    `the command that produced this spec. Nothing is recorded until that command exits 0.`,
+    "",
+  ];
+
+  if (context) {
+    parts.push(
+      "## What the CLI already established",
+      "",
+      "These are facts, not suggestions. Do not contradict them; if one is wrong,",
+      "say so in your reply to the user rather than silently changing it.",
+      "",
+      fence("json", JSON.stringify(context, null, 2)),
+      "",
+    );
+  }
+
+  if (rejects.length) {
+    parts.push(
+      "## What will be rejected",
+      "",
+      ...rejects.map((r) => `- ${r}`),
+      "",
+    );
+  }
+
+  for (const ref of references) {
+    parts.push(`## Reference: ${ref}`, "", reference(ref), "");
+  }
+
+  parts.push(
+    "## Schema the answer must satisfy",
+    "",
+    fence("json", JSON.stringify(schema, null, 2)),
+    "",
+  );
+
+  writeFileAtomic(specPath, parts.join("\n"));
+  return { specPath, answerPath };
+}
+
+/**
+ * Read, validate, and hand back the agent's answer.
+ *
+ * @param {object} o
+ * @param {import("./state.mjs").Project} o.project
+ * @param {string} o.name
+ * @param {string} o.schemaName
+ * @returns {object}
+ */
+export function acceptTaskAnswer({ project, name, schemaName }) {
+  const answerPath = project.answerPath(name);
+  if (!exists(answerPath)) {
+    throw artifactError(
+      `expected an answer at ${answerPath}.\n` +
+        `Read ${project.specPath(name)}, write the JSON it asks for, then re-run with --accept.`,
+    );
+  }
+  const data = readJson(answerPath);
+  return assertValid(REPO_ROOT, schemaName, data, {
+    source: path.basename(answerPath),
+  });
+}
+
+/**
+ * Standard two-phase command body. `build` collects deterministic context,
+ * `finish` runs on --accept with the validated answer.
+ *
+ * @returns {{mode: "emit"|"accept", value: any}}
+ */
+export function twoPhase({ project, flags, name, schemaName, emit, accept }) {
+  if (flags.accept) {
+    const answer = acceptTaskAnswer({ project, name, schemaName });
+    return { mode: "accept", value: accept(answer) };
+  }
+  return { mode: "emit", value: emit() };
+}

--- a/cli/lib/util.mjs
+++ b/cli/lib/util.mjs
@@ -1,0 +1,179 @@
+/**
+ * Shared primitives: exit codes, output, and atomic filesystem helpers.
+ *
+ * Exit codes are the contract. Every command must exit non-zero on failure —
+ * "looks good" is never a gate.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export const EXIT = {
+  OK: 0,
+  /** A gate failed: the work is real but does not pass. */
+  GATE: 1,
+  /** The caller invoked us wrongly. */
+  USAGE: 2,
+  /** The environment is not fit to run: missing HyperFrames, missing ffmpeg. */
+  ENV: 3,
+  /** A required artifact was absent or failed schema validation. */
+  ARTIFACT: 4,
+};
+
+export class BragError extends Error {
+  constructor(message, code = EXIT.GATE, detail = null) {
+    super(message);
+    this.name = "BragError";
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+export const usage = (m, d) => new BragError(m, EXIT.USAGE, d);
+export const envError = (m, d) => new BragError(m, EXIT.ENV, d);
+export const artifactError = (m, d) => new BragError(m, EXIT.ARTIFACT, d);
+export const gateError = (m, d) => new BragError(m, EXIT.GATE, d);
+
+/* ------------------------------------------------------------------ output */
+
+let JSON_MODE = false;
+let QUIET = false;
+
+export function configureOutput({ json = false, quiet = false } = {}) {
+  JSON_MODE = json;
+  QUIET = quiet;
+}
+
+export const isJsonMode = () => JSON_MODE;
+
+const write = (stream, s) => stream.write(s + "\n");
+
+export function say(msg) {
+  if (!QUIET && !JSON_MODE) write(process.stdout, msg);
+}
+
+export function detail(msg) {
+  if (!QUIET && !JSON_MODE) write(process.stdout, "  " + msg);
+}
+
+export function warn(msg) {
+  if (!JSON_MODE) write(process.stderr, "warning: " + msg);
+}
+
+export function fail(msg) {
+  write(process.stderr, "error: " + msg);
+}
+
+/** The single structured-output path. Commands print at most one of these. */
+export function emitJson(payload) {
+  write(process.stdout, JSON.stringify(payload, null, 2));
+}
+
+/**
+ * Report a command result. In --json mode the payload is the whole output;
+ * otherwise `lines` is printed for humans.
+ */
+export function report(payload, lines = []) {
+  if (JSON_MODE) emitJson(payload);
+  else for (const l of lines) say(l);
+}
+
+/* ------------------------------------------------------------------ filesystem */
+
+export function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Write atomically via a sibling temp file + rename, so a crashed run can never
+ * leave a half-written artifact that a later stage would happily read.
+ */
+export function writeFileAtomic(file, contents) {
+  ensureDir(path.dirname(file));
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, contents);
+  fs.renameSync(tmp, file);
+  return file;
+}
+
+/** Stable JSON: sorted keys, trailing newline. Byte-identical across runs. */
+export function stableStringify(value) {
+  const seen = new WeakSet();
+  const norm = (v) => {
+    if (v === null || typeof v !== "object") return v;
+    if (seen.has(v)) throw new Error("cannot serialize a cycle");
+    seen.add(v);
+    if (Array.isArray(v)) return v.map(norm);
+    const out = {};
+    for (const k of Object.keys(v).sort()) {
+      if (v[k] !== undefined) out[k] = norm(v[k]);
+    }
+    return out;
+  };
+  return JSON.stringify(norm(value), null, 2) + "\n";
+}
+
+export function writeJson(file, value) {
+  return writeFileAtomic(file, stableStringify(value));
+}
+
+export function readJson(file, { optional = false } = {}) {
+  if (!fs.existsSync(file)) {
+    if (optional) return null;
+    throw artifactError(`missing artifact: ${file}`);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (e) {
+    throw artifactError(`${file} is not valid JSON: ${e.message}`);
+  }
+}
+
+export const exists = (p) => fs.existsSync(p);
+
+export function sha256(input) {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+export function sha256File(file) {
+  return sha256(fs.readFileSync(file));
+}
+
+/** Recursive file list, relative to `root`, sorted — for determinism checks. */
+export function walkFiles(root, { skip = new Set([".git", "node_modules"]) } = {}) {
+  const out = [];
+  const walk = (dir, rel) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries.sort((a, b) => (a.name < b.name ? -1 : 1))) {
+      if (skip.has(e.name)) continue;
+      const abs = path.join(dir, e.name);
+      const r = rel ? `${rel}/${e.name}` : e.name;
+      if (e.isDirectory()) walk(abs, r);
+      else if (e.isFile()) out.push(r);
+    }
+  };
+  walk(root, "");
+  return out;
+}
+
+/* ------------------------------------------------------------------ misc */
+
+export const slug = (s) =>
+  String(s)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64) || "untitled";
+
+export const round = (n, dp = 3) => Number(Number(n).toFixed(dp));
+
+export function pluralize(n, one, many = one + "s") {
+  return `${n} ${n === 1 ? one : many}`;
+}

--- a/cli/lib/watch/bundle.mjs
+++ b/cli/lib/watch/bundle.mjs
@@ -1,0 +1,116 @@
+/**
+ * The watch bundle: what a render looks like, at the moments that matter.
+ *
+ * Frames are sampled semantically rather than on a fixed interval. A grid of
+ * evenly-spaced stills mostly catches transitions and mostly misses the frames
+ * the video was built around; sampling from the timing plan catches the ones
+ * that carry the meaning — each settled read, both sides of every cut, the
+ * frame every platform will use as the thumbnail, and the last thing on screen.
+ */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { scheduleReading, withStarts } from "../compile/targets.mjs";
+import fs from "node:fs";
+import { ensureDir, envError, gateError } from "../util.mjs";
+import { aHash, grabGray, isFlat, rowInk } from "./pixels.mjs";
+
+/**
+ * @returns {{at:number, kind:string, scene?:string, why:string}[]} sorted, deduped
+ */
+export function chooseTimes(graph, { duration }) {
+  const scenes = withStarts(graph);
+  const out = [];
+  const add = (at, kind, why, scene) => {
+    if (at < 0 || at > duration) return;
+    out.push({ at: Number(at.toFixed(2)), kind, why, scene });
+  };
+
+  add(0, "frame_zero", "what every platform grabs as the thumbnail");
+
+  for (const scene of scenes) {
+    add(scene.start + scene.duration / 2, "midpoint", `middle of ${scene.id}`, scene.id);
+    for (const line of scheduleReading(scene)) {
+      /* Just past settle: the copy has arrived and has not started to leave. */
+      add(line.settled + 0.12, "settled_read", `"${truncate(line.text)}" settled`, scene.id);
+    }
+  }
+
+  for (const seam of graph.seams ?? []) {
+    add(seam.at - 0.08, "pre_cut", `just before ${seam.from}→${seam.to}`, seam.from);
+    add(seam.at + 0.02, "at_cut", `on the cut ${seam.from}→${seam.to}`, seam.to);
+    add(seam.at + 0.25, "post_cut", `just after ${seam.from}→${seam.to}`, seam.to);
+  }
+
+  add(duration - 0.1, "final", "the last thing on screen");
+
+  const seen = new Set();
+  return out
+    .sort((a, b) => a.at - b.at)
+    .filter((f) => {
+      const key = f.at.toFixed(2);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
+/**
+ * Extract stills and their measurements.
+ *
+ * @returns {{frames: object[], contactSheet: string|null}}
+ */
+export function buildBundle({ video, graph, duration, outDir, sheet = true }) {
+  const dir = ensureDir(path.join(outDir, "frames"));
+  const times = chooseTimes(graph, { duration });
+  const frames = [];
+
+  /* Numbered sequentially so the contact sheet can read them as an image
+     sequence. Glob input is not reliable across ffmpeg builds on Windows, and
+     a sheet that silently fails to build is a review surface nobody sees. The
+     semantic name of each frame lives in watch.json instead of the filename. */
+  times.forEach((t, i) => {
+    const name = `${String(i + 1).padStart(3, "0")}.jpg`;
+    const file = path.join(dir, name);
+    const res = spawnSync(
+      "ffmpeg",
+      ["-v", "error", "-ss", String(t.at), "-i", video, "-frames:v", "1", "-q:v", "3", file, "-y"],
+      { encoding: "utf8", timeout: 120_000 },
+    );
+    if (res.error?.code === "ENOENT") throw envError("ffmpeg is not on PATH");
+    if (res.status !== 0) throw gateError(`could not extract ${t.at}s: ${res.stderr?.trim()}`);
+
+    const gray = grabGray(video, t.at);
+    frames.push({
+      ...t,
+      file: path.relative(outDir, file).split(path.sep).join("/"),
+      hash: aHash(gray).toString(16),
+      ink: rowInk(gray).map((v) => Number(v.toFixed(3))),
+      tone: isFlat(gray),
+    });
+  });
+
+  let contactSheet = null;
+  if (sheet && frames.length) {
+    const target = path.join(outDir, "contact-sheet.jpg");
+    const cols = Math.min(4, frames.length);
+    const rows = Math.ceil(frames.length / cols);
+    const res = spawnSync(
+      "ffmpeg",
+      [
+        "-v", "error", "-y",
+        "-i", path.join(dir, "%03d.jpg"),
+        "-vf", `scale=480:-1,tile=${cols}x${rows}:padding=8:margin=8:color=0x111318`,
+        "-frames:v", "1",
+        target,
+      ],
+      { encoding: "utf8", timeout: 180_000 },
+    );
+    if (res.status === 0 && fs.existsSync(target)) contactSheet = target;
+    else if (res.status !== 0) throw gateError(`contact sheet failed: ${String(res.stderr).trim()}`);
+  }
+
+  return { frames, contactSheet };
+}
+
+const truncate = (s, n = 42) => (String(s).length > n ? `${String(s).slice(0, n)}…` : String(s));

--- a/cli/lib/watch/pixels.mjs
+++ b/cli/lib/watch/pixels.mjs
@@ -71,12 +71,23 @@ export function rowInk(frame) {
   let peak = 0;
   for (let y = 0; y < h; y++) {
     let acc = 0;
-    for (let x = 0; x < w; x++) acc += Math.abs(data[y * w + x] - background);
+    for (let x = 0; x < w; x++) {
+      const departure = Math.abs(data[y * w + x] - background);
+      /* Below the noise floor is not ink. Rows are normalised against the
+         frame's own peak, so on a sparse frame an invisible few-level shift —
+         an encoder seam, a faint gradient, a panel a shade off the page —
+         normalises up into something that reads as content, and the caption
+         detector reports copy in a band that is empty to the eye. */
+      if (departure > INK_FLOOR) acc += departure;
+    }
     rows[y] = acc / w;
     if (rows[y] > peak) peak = rows[y];
   }
   return peak > 0 ? rows.map((v) => v / peak) : rows.map(() => 0);
 }
+
+/** Levels of departure from background below which a pixel is not ink. */
+const INK_FLOOR = 12;
 
 /**
  * Average hash: downsample to 8×8, one bit per cell against the mean.

--- a/cli/lib/watch/pixels.mjs
+++ b/cli/lib/watch/pixels.mjs
@@ -1,0 +1,126 @@
+/**
+ * Reading the render's actual pixels.
+ *
+ * Detection works on the rendered frame, not on the DOM brag authored. That
+ * matters: the whole reason a review layer exists is that `check` can pass
+ * while the video is wrong, and a check that reads brag's own intent back to
+ * itself would repeat the same mistake.
+ *
+ * Pixels arrive as raw 8-bit grayscale straight from ffmpeg, so nothing here
+ * needs an image-decoding dependency and every measurement is reproducible.
+ */
+
+import { spawnSync } from "node:child_process";
+import { envError, gateError } from "../util.mjs";
+
+/**
+ * Grab one frame as a raw grayscale buffer.
+ * @returns {{w:number,h:number,data:Uint8Array}}
+ */
+export function grabGray(video, atSeconds, { w = 64, h = 36 } = {}) {
+  const res = spawnSync(
+    "ffmpeg",
+    [
+      "-v", "error",
+      "-ss", String(atSeconds),
+      "-i", video,
+      "-frames:v", "1",
+      "-vf", `scale=${w}:${h}:flags=area,format=gray`,
+      "-f", "rawvideo",
+      "-",
+    ],
+    { encoding: "buffer", maxBuffer: 16 * 1024 * 1024, timeout: 120_000 },
+  );
+  if (res.error?.code === "ENOENT") throw envError("ffmpeg is not on PATH");
+  if (res.status !== 0) {
+    throw gateError(`ffmpeg could not read ${video} at ${atSeconds}s: ${String(res.stderr).trim()}`);
+  }
+  const data = new Uint8Array(res.stdout);
+  if (data.length < w * h) {
+    throw gateError(`frame at ${atSeconds}s returned ${data.length} bytes, expected ${w * h}`);
+  }
+  return { w, h, data: data.subarray(0, w * h) };
+}
+
+export const mean = (data) => {
+  let sum = 0;
+  for (const v of data) sum += v;
+  return sum / data.length;
+};
+
+export function stdDev(data) {
+  const m = mean(data);
+  let acc = 0;
+  for (const v of data) acc += (v - m) ** 2;
+  return Math.sqrt(acc / data.length);
+}
+
+/**
+ * Per-row ink: how far each row departs from the frame's background level.
+ * Text is ink; a flat background is not. Returns one value per row, 0..1.
+ */
+export function rowInk(frame) {
+  const { w, h, data } = frame;
+
+  /* The background is the most common level, approximated by the median —
+     robust to a bright headline or a dark panel. */
+  const sorted = Array.from(data).sort((a, b) => a - b);
+  const background = sorted[Math.floor(sorted.length / 2)];
+
+  const rows = new Array(h);
+  let peak = 0;
+  for (let y = 0; y < h; y++) {
+    let acc = 0;
+    for (let x = 0; x < w; x++) acc += Math.abs(data[y * w + x] - background);
+    rows[y] = acc / w;
+    if (rows[y] > peak) peak = rows[y];
+  }
+  return peak > 0 ? rows.map((v) => v / peak) : rows.map(() => 0);
+}
+
+/**
+ * Average hash: downsample to 8×8, one bit per cell against the mean.
+ * Enough to answer "is this the same layout again?", which is what the
+ * anti-sameness check actually asks — not "is this the same image".
+ */
+export function aHash(frame) {
+  const { w, h, data } = frame;
+  const cells = new Array(64).fill(0);
+  const counts = new Array(64).fill(0);
+  for (let y = 0; y < h; y++) {
+    const by = Math.min(7, Math.floor((y / h) * 8));
+    for (let x = 0; x < w; x++) {
+      const bx = Math.min(7, Math.floor((x / w) * 8));
+      const i = by * 8 + bx;
+      cells[i] += data[y * w + x];
+      counts[i]++;
+    }
+  }
+  const avg = cells.map((v, i) => (counts[i] ? v / counts[i] : 0));
+  const m = mean(avg);
+  let bits = 0n;
+  for (let i = 0; i < 64; i++) if (avg[i] > m) bits |= 1n << BigInt(i);
+  return bits;
+}
+
+export function hamming(a, b) {
+  let x = a ^ b;
+  let n = 0;
+  while (x) {
+    n += Number(x & 1n);
+    x >>= 1n;
+  }
+  return n;
+}
+
+/** A frame with almost no tonal range is black, white, or a dead fade. */
+export function isFlat(frame, { maxStdDev = 3, darkBelow = 12 } = {}) {
+  const m = mean(frame.data);
+  const sd = stdDev(frame.data);
+  return {
+    flat: sd <= maxStdDev,
+    dark: m <= darkBelow,
+    mean: Number(m.toFixed(2)),
+    stdDev: Number(sd.toFixed(2)),
+  };
+}

--- a/cli/lib/worlds.mjs
+++ b/cli/lib/worlds.mjs
@@ -112,9 +112,20 @@ export function assignLayouts(world, scenes, seams = []) {
     if (seam.carrier) carriedInto.set(seam.to, seam.from);
   }
 
+  /* Two layouts with the same anchor put content in the same horizontal band,
+     and a band is what a viewer reads as "the same picture again" — the repeat
+     detector measures exactly that, from pixels. Rotating layout ids alone can
+     therefore produce a film that looks repetitive while every id is different,
+     so candidates are ordered by how little their anchor has been spent. */
+  const anchorUse = new Map();
+
   for (const scene of scenes) {
     const preferred = layouts.filter((l) => !scene.role || l.best_for?.includes(scene.role));
     let ordered = [...(preferred.length ? preferred : layouts), ...layouts];
+    ordered = ordered
+      .map((l, i) => ({ l, i }))
+      .sort((a, b) => (anchorUse.get(a.l.anchor) ?? 0) - (anchorUse.get(b.l.anchor) ?? 0) || a.i - b.i)
+      .map((e) => e.l);
 
     const carriedFrom = carriedInto.get(scene.id);
     const inherited = carriedFrom ? byScene.get(carriedFrom) : null;
@@ -126,6 +137,7 @@ export function assignLayouts(world, scenes, seams = []) {
       layouts[0];
 
     used.set(pick.id, (used.get(pick.id) ?? 0) + 1);
+    anchorUse.set(pick.anchor, (anchorUse.get(pick.anchor) ?? 0) + 1);
     previous = pick.id;
     byScene.set(scene.id, pick);
     out.push({ scene: scene.id, layout: pick, carried: Boolean(inherited) });

--- a/cli/lib/worlds.mjs
+++ b/cli/lib/worlds.mjs
@@ -1,0 +1,134 @@
+/**
+ * The visual world catalogue.
+ *
+ * Worlds are data, loaded and validated at run time. The distinctness gate is
+ * the point: fifteen names for three looks is the obvious failure mode of a
+ * catalogue like this, so two worlds declaring the same
+ * camera × depth × transition-family triple are rejected rather than shipped.
+ *
+ * The catalogue is deliberately small and grows as each new world is shown to
+ * render differently from the others. A world that does not change the frame
+ * is a name, not a look.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { assertValid } from "./schema.mjs";
+import { REPO_ROOT } from "./state.mjs";
+import { gateError } from "./util.mjs";
+
+const DIR = path.join(REPO_ROOT, "worlds");
+
+let cache = null;
+
+export function loadWorlds() {
+  if (cache) return cache;
+  if (!fs.existsSync(DIR)) throw gateError(`no world catalogue at ${DIR}`);
+
+  const worlds = fs
+    .readdirSync(DIR)
+    .filter((f) => f.endsWith(".json"))
+    .sort()
+    .map((f) => {
+      const parsed = JSON.parse(fs.readFileSync(path.join(DIR, f), "utf8"));
+      return assertValid(REPO_ROOT, "visual_world", parsed, { source: f });
+    });
+
+  assertDistinct(worlds);
+  cache = worlds;
+  return worlds;
+}
+
+export function getWorld(id) {
+  const world = loadWorlds().find((w) => w.id === id);
+  if (!world) {
+    throw gateError(
+      `no visual world "${id}". Available: ${loadWorlds().map((w) => w.id).join(", ")}`,
+    );
+  }
+  return world;
+}
+
+/** The triple that has to be unique for a world to be worth having. */
+export const worldSignature = (w) =>
+  `${w.camera_model}|${w.depth_levels}|${[...w.transition_families].sort().join("+")}`;
+
+export function assertDistinct(worlds) {
+  const seen = new Map();
+  const clashes = [];
+  for (const w of worlds) {
+    const sig = worldSignature(w);
+    if (seen.has(sig)) clashes.push(`"${w.id}" and "${seen.get(sig)}" both declare ${sig}`);
+    else seen.set(sig, w.id);
+  }
+  if (clashes.length) {
+    throw gateError(
+      "two visual worlds are the same look under different names:\n" +
+        clashes.map((c) => `  - ${c}`).join("\n") +
+        "\n\nGive one a different camera, depth or transition vocabulary, or delete it.",
+    );
+  }
+  return true;
+}
+
+/** Worlds that suit a product surface, best first. */
+export function worldsFor(surfaceType) {
+  const all = loadWorlds();
+  const suited = all.filter((w) => w.suits_surfaces?.includes(surfaceType));
+  return suited.length ? suited : all;
+}
+
+/**
+ * Assign a layout to every scene.
+ *
+ * Scenes prefer a layout listed for their narrative role, but never the layout
+ * the previous scene used, and no layout may carry more than 40% of the film.
+ * Consecutive scenes composed identically is what makes a video read as a
+ * slideshow, and it is cheap to prevent here rather than detect later.
+ */
+export function assignLayouts(world, scenes, seams = []) {
+  const layouts = world.layouts;
+  /* Matches the 40% ceiling the sameness gate enforces. Rounding up instead
+     would let the assigner produce a film the gate then refuses. */
+  const budget = Math.max(1, Math.floor(scenes.length * 0.4));
+  const used = new Map();
+  const out = [];
+  const byScene = new Map();
+  let previous = null;
+
+  /* A seam that hands an element across the cut needs that element in the same
+     place and at the same size on both sides. Matching only the scale is not
+     enough: the gate measures the carrier's centre and calls a shifted one
+     position drift, which is exactly right — an object that jumps 127px has
+     not been handed across, it has been replaced.
+
+     So a carried cut pins the incoming scene to the outgoing scene's layout.
+     That is in tension with rotating layouts for variety, and the carrier wins:
+     visual continuity across the cut is the whole point of declaring one. The
+     layout-overuse gate still caps how much of a film any one layout carries,
+     so this cannot quietly collapse into a single composition. */
+  const carriedInto = new Map();
+  for (const seam of seams) {
+    if (seam.carrier) carriedInto.set(seam.to, seam.from);
+  }
+
+  for (const scene of scenes) {
+    const preferred = layouts.filter((l) => !scene.role || l.best_for?.includes(scene.role));
+    let ordered = [...(preferred.length ? preferred : layouts), ...layouts];
+
+    const carriedFrom = carriedInto.get(scene.id);
+    const inherited = carriedFrom ? byScene.get(carriedFrom) : null;
+
+    const pick =
+      inherited ??
+      ordered.find((l) => l.id !== previous && (used.get(l.id) ?? 0) < budget) ??
+      ordered.find((l) => l.id !== previous) ??
+      layouts[0];
+
+    used.set(pick.id, (used.get(pick.id) ?? 0) + 1);
+    previous = pick.id;
+    byScene.set(scene.id, pick);
+    out.push({ scene: scene.id, layout: pick, carried: Boolean(inherited) });
+  }
+  return out;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@00prabalk00/brag-video",
+  "version": "1.0.0-alpha.1",
+  "private": true,
+  "type": "module",
+  "description": "Turn a project into a short, shareable launch video. Brag 1.0: a creative system that compiles to HyperFrames.",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "bin": {
+    "brag": "cli/brag.mjs"
+  },
+  "scripts": {
+    "brag": "node cli/brag.mjs",
+    "doctor": "node cli/brag.mjs doctor",
+    "test": "node --test test/*.test.mjs",
+    "check-docs": "node scripts/check-docs.mjs"
+  },
+  "dependencies": {
+    "@xterm/headless": "^6.0.0"
+  }
+}

--- a/schemas/concept.schema.json
+++ b/schemas/concept.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "brag/concept",
+  "title": "Concept set",
+  "description": "At least three genuinely different ways to make this video. Generating one storyboard straight from inspection produces the same film every time; the point of a set is that they should be hard to choose between.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "concepts"],
+  "properties": {
+    "schema": { "const": "brag.concepts/1" },
+    "concepts": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 6,
+      "items": { "$ref": "#/$defs/concept" }
+    }
+  },
+  "$defs": {
+    "concept": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "premise", "central_metaphor", "visual_rule", "emotional_arc", "forbidden_motifs"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$", "maxLength": 40 },
+        "name": { "type": "string", "minLength": 3, "maxLength": 60 },
+
+        "premise": {
+          "description": "What the viewer watches happen. A description of the film, not of the product.",
+          "type": "string",
+          "minLength": 40,
+          "maxLength": 700
+        },
+
+        "central_metaphor": {
+          "description": "The one idea every scene serves. \"Context is a baton\" is a metaphor; \"it is fast and reliable\" is not.",
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 160
+        },
+
+        "visual_rule": {
+          "description": "The constraint that decides every later question. Strong enough that violating it would be obvious.",
+          "type": "string",
+          "minLength": 10,
+          "maxLength": 240
+        },
+
+        "emotional_arc": {
+          "description": "Where the viewer starts and where they end, e.g. fragmentation to continuity.",
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 160
+        },
+
+        "forbidden_motifs": {
+          "description": "What this concept must never become. Usually the generic version of itself — the thing it would drift into under pressure.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 3 }
+        },
+
+        "suggested_world": {
+          "description": "A visual world id, if one obviously fits. The director may override it.",
+          "type": "string"
+        },
+
+        "beats": {
+          "description": "Rough shape only. The scene graph is built later, from the concept that wins.",
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 8,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["what"],
+            "properties": {
+              "what": { "type": "string", "minLength": 5 },
+              "proof_ref": { "type": "string" },
+              "role": {
+                "enum": ["Hook", "Problem", "Product_Intro", "Key_Feature", "Benefits", "Social_Proof", "CTA", "Brand_Outro"]
+              }
+            }
+          }
+        },
+
+        "why_this_product": {
+          "description": "Why this concept could not be reused for a different product. If it could, it is a template.",
+          "type": "string",
+          "minLength": 20,
+          "maxLength": 400
+        },
+
+        "risk": {
+          "description": "The most likely way this concept fails in execution.",
+          "type": "string",
+          "maxLength": 300
+        }
+      }
+    }
+  }
+}

--- a/schemas/concept_scores.schema.json
+++ b/schemas/concept_scores.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "brag/concept_scores",
+  "title": "Concept scores",
+  "description": "Ratings for the criteria a model can legitimately judge. Novelty and difference-from-previous are deliberately absent: those are computed by the CLI, because a model scoring its own concepts on originality is grading its own homework.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "scores"],
+  "properties": {
+    "schema": { "const": "brag.concept_scores/1" },
+    "scores": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["concept_id", "criteria"],
+        "properties": {
+          "concept_id": { "type": "string" },
+          "criteria": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["product_clarity", "product_proof", "emotional_strength", "platform_fit", "silent_comprehension"],
+            "properties": {
+              "product_clarity": { "$ref": "#/$defs/rating" },
+              "product_proof": { "$ref": "#/$defs/rating" },
+              "emotional_strength": { "$ref": "#/$defs/rating" },
+              "platform_fit": { "$ref": "#/$defs/rating" },
+              "silent_comprehension": { "$ref": "#/$defs/rating" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "rating": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "because"],
+      "properties": {
+        "score": { "type": "integer", "minimum": 1, "maximum": 5 },
+        "because": {
+          "description": "One sentence naming the specific thing in the concept that earns this score. A justification that would fit any concept is not one.",
+          "type": "string",
+          "minLength": 15,
+          "maxLength": 300
+        }
+      }
+    }
+  }
+}

--- a/schemas/positioning.schema.json
+++ b/schemas/positioning.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "brag/positioning",
+  "title": "Positioning",
+  "description": "Audience, angle and the claim-to-source map. The gate on this stage is that every claim the video intends to make resolves to a proof id in the product model — which is what stops a good-sounding line entering the edit unsupported.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "audience", "angle", "claims", "action"],
+  "properties": {
+    "schema": { "const": "brag.positioning/1" },
+
+    "audience": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["who", "already_knows", "cares_about"],
+      "properties": {
+        "who": { "type": "string", "minLength": 8, "maxLength": 200 },
+        "already_knows": {
+          "description": "What you can assume, so the video does not spend its first seconds explaining it.",
+          "type": "string",
+          "maxLength": 300
+        },
+        "cares_about": { "type": "string", "maxLength": 300 },
+        "destination": {
+          "description": "Where this will be watched. Changes pacing, framing and whether sound can be assumed.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "enum": ["x", "linkedin", "discord", "hacker_news", "product_hunt", "readme", "conference", "internal", "youtube", "tiktok", "instagram"] }
+        }
+      }
+    },
+
+    "angle": {
+      "description": "The one sentence the video argues. Not a feature list.",
+      "type": "string",
+      "minLength": 15,
+      "maxLength": 300
+    },
+
+    "claims": {
+      "description": "Everything the video will assert, each bound to a proof id. Unbound claims fail this stage.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["text", "proof_ref"],
+        "properties": {
+          "text": { "type": "string", "minLength": 3 },
+          "proof_ref": { "type": "string" },
+          "verbatim": {
+            "description": "True when this must be shown in the product's own words rather than paraphrased.",
+            "type": "boolean"
+          }
+        }
+      }
+    },
+
+    "action": {
+      "description": "What a convinced viewer does next, in the product's own terms.",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 200
+    },
+
+    "avoid": {
+      "description": "Framings that are wrong for this product even though they would land — competitor comparisons it does not want, categories it is not in.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+
+    "generated_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/schemas/product_model.schema.json
+++ b/schemas/product_model.schema.json
@@ -1,0 +1,257 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "brag/product_model",
+  "title": "Product model",
+  "description": "The source of truth for every later stage. Nothing may appear in a video that is not traceable to this document, and nothing enters this document without a source reference.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "surface_type",
+    "primary_user",
+    "problem",
+    "mechanism",
+    "proof",
+    "visual_surfaces",
+    "forbidden_claims",
+    "verbatim_copy"
+  ],
+  "properties": {
+    "schema": { "const": "brag.product_model/1" },
+
+    "surface_type": {
+      "description": "How the product is actually experienced. Drives which inspection adapter and which capture adapter run. `mixed` requires primary_surface.",
+      "enum": [
+        "website",
+        "cli",
+        "library",
+        "api",
+        "desktop",
+        "mobile",
+        "game",
+        "hardware",
+        "research",
+        "mixed"
+      ]
+    },
+    "primary_surface": {
+      "description": "Required when surface_type is `mixed`: the one surface the video will actually show.",
+      "$ref": "#/$defs/surfaceEnum"
+    },
+
+    "name": { "type": "string", "minLength": 1, "maxLength": 80 },
+    "one_line": {
+      "description": "What it does, in the project's own terms. No positioning yet.",
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 240
+    },
+
+    "primary_user": {
+      "description": "Who this is for, specifically. 'developers' is too broad to direct a video.",
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 200
+    },
+    "problem": {
+      "description": "The problem in the user's world, not the feature's absence.",
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 400
+    },
+    "mechanism": {
+      "description": "How it actually works. Concrete enough that a viewer could picture it.",
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 400
+    },
+
+    "proof": {
+      "description": "Every claim the video is allowed to make, each with the evidence that supports it. A claim with no source cannot be shown.",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/proof" }
+    },
+
+    "visual_surfaces": {
+      "description": "What can actually be put on screen. For a CLI the terminal is a visual surface, not supporting material.",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/visualSurface" }
+    },
+
+    "forbidden_claims": {
+      "description": "Things that are true-adjacent but unsupported, or that the maintainer does not want said. Enforced by substring match at review time.",
+      "type": "array",
+      "items": { "type": "string", "minLength": 3 }
+    },
+
+    "verbatim_copy": {
+      "description": "Strings that must appear exactly as written, each traceable to a file. This is what makes the video's copy checkable rather than plausible.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/verbatim" }
+    },
+
+    "identity": {
+      "description": "The project's own visual identity, extracted rather than invented.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "palette": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["role", "value"],
+            "properties": {
+              "role": { "type": "string" },
+              "value": { "type": "string", "pattern": "^(#|rgb|hsl|oklch|var\\()" },
+              "source": { "$ref": "#/$defs/source" }
+            }
+          }
+        },
+        "display_font": { "type": "string" },
+        "body_font": { "type": "string" },
+        "mono_font": { "type": "string" },
+        "logo": { "$ref": "#/$defs/source" },
+        "logo_usable_on_dark": {
+          "description": "False when the mark is dark-on-transparent and would vanish on a dark ground. Recorded so the director does not discover it at render time.",
+          "type": "boolean"
+        }
+      }
+    },
+
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": { "type": "string" },
+        "license": { "type": "string" },
+        "default_branch": { "type": "string" },
+        "recent_commits": {
+          "description": "Real history. Usable on screen for products whose story is the work itself.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["sha", "subject"],
+            "properties": {
+              "sha": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
+              "subject": { "type": "string" },
+              "date": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+
+    "signals": {
+      "description": "What the deterministic scan found. Written by the CLI, not the model; present so classification is auditable.",
+      "type": "object"
+    },
+
+    "generated_at": { "type": "string", "format": "date-time" }
+  },
+
+  "$defs": {
+    "surfaceEnum": {
+      "enum": [
+        "website",
+        "cli",
+        "library",
+        "api",
+        "desktop",
+        "mobile",
+        "game",
+        "hardware",
+        "research"
+      ]
+    },
+
+    "source": {
+      "description": "Where a fact came from. Byte offsets make the fidelity check exact rather than fuzzy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["file"],
+      "properties": {
+        "file": { "type": "string", "minLength": 1 },
+        "line": { "type": "integer", "minimum": 1 },
+        "byte_start": { "type": "integer", "minimum": 0 },
+        "byte_end": { "type": "integer", "minimum": 0 },
+        "note": { "type": "string" }
+      }
+    },
+
+    "proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "claim", "evidence", "strength"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$" },
+        "claim": { "type": "string", "minLength": 5, "maxLength": 300 },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/source" }
+        },
+        "strength": {
+          "description": "measured: a number produced by a real run. demonstrated: the product visibly doing it. documented: the project states it. inferred: true but not stated — the weakest thing a video may show, and never as a headline.",
+          "enum": ["measured", "demonstrated", "documented", "inferred"]
+        },
+        "shows_well": {
+          "description": "Whether this proof can carry a scene on its own.",
+          "type": "boolean"
+        }
+      }
+    },
+
+    "visualSurface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "description"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$" },
+        "kind": {
+          "enum": [
+            "terminal",
+            "web_page",
+            "editor",
+            "api_exchange",
+            "file_tree",
+            "diagram",
+            "chart",
+            "app_window",
+            "device",
+            "document",
+            "code"
+          ]
+        },
+        "description": { "type": "string", "minLength": 5 },
+        "capture": {
+          "description": "How this surface will be recorded. `synthesized` means brag will build it from real strings rather than record it.",
+          "enum": ["terminal_tape", "browser", "api_tape", "editor", "screenshot", "synthesized", "none"]
+        },
+        "source": { "$ref": "#/$defs/source" },
+        "priority": { "type": "integer", "minimum": 1, "maximum": 5 }
+      }
+    },
+
+    "verbatim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "text", "source"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$" },
+        "text": { "type": "string", "minLength": 1 },
+        "source": { "$ref": "#/$defs/source" },
+        "kind": {
+          "enum": ["command", "output", "headline", "tagline", "label", "code", "metric", "path", "commit"]
+        },
+        "whitespace_significant": {
+          "description": "True when the exact spacing matters — aligned CLI output, indented trees, code. The compiler must not normalise it.",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/schemas/review_narrative.schema.json
+++ b/schemas/review_narrative.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "brag/review_narrative",
+  "title": "Narrative review",
+  "description": "What someone took away from watching, answered without sight of the plan. The value of this artifact depends entirely on the reviewer never having read the scene graph: an agent shown the intent will confirm the intent.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "product", "problem", "proof", "scenes", "unsupported", "silent", "readable", "ending"],
+  "properties": {
+    "schema": { "const": "brag.review_narrative/1" },
+    "product": {
+      "description": "What is this a video for? Name it as the video names it, or say you could not tell.",
+      "type": "string",
+      "minLength": 2
+    },
+    "problem": { "description": "What problem does it claim to solve?", "type": "string", "minLength": 2 },
+    "proof": {
+      "description": "What evidence was actually shown, as opposed to asserted.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "scenes": {
+      "description": "One line per distinct moment you could make out, in order.",
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "unsupported": {
+      "description": "Anything stated that nothing on screen backed up.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "silent": {
+      "description": "Could the story be followed with the sound off?",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["yes", "because"],
+      "properties": { "yes": { "type": "boolean" }, "because": { "type": "string", "minLength": 10 } }
+    },
+    "readable": {
+      "description": "Anything you could not read in the time it was on screen.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "ending": { "description": "What is a convinced viewer meant to do next?", "type": "string" },
+    "confusions": {
+      "description": "Anything that actively misled you. The most useful field here.",
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/schemas/revision.schema.json
+++ b/schemas/revision.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "brag/revision",
+  "title": "Scoped revision",
+  "description": "One change, scoped to named scenes. Everything unnamed must recompile byte-identical, which is checked rather than trusted.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "intent", "scenes_touched", "scenes"],
+  "properties": {
+    "schema": { "const": "brag.revision/1" },
+    "intent": { "type": "string", "minLength": 3 },
+    "scenes_touched": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "scenes": { "type": "array", "items": { "type": "object" } },
+    "blocked": {
+      "description": "Set this instead of widening the scope when the change cannot be made within the scenes named.",
+      "type": "string"
+    }
+  }
+}

--- a/schemas/scene_graph.schema.json
+++ b/schemas/scene_graph.schema.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "brag/scene_graph",
+  "title": "Scene graph",
+  "description": "A connected graph, not a list of slides. Scenes carry purpose, proof and continuity; seams carry vectors. This compiles into STORYBOARD.md, ledger.json and the motion.json sidecars — it is upstream of any one composition, which is what makes format variants a recompile rather than a copy.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "format", "objects", "scenes", "seams"],
+  "properties": {
+    "schema": { "const": "brag.scene_graph/1" },
+
+    "concept": {
+      "description": "The locked concept this graph serves. Every scene must be explicable by it.",
+      "type": "string"
+    },
+    "visual_world": { "type": "string" },
+
+    "format": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["width", "height", "fps"],
+      "properties": {
+        "width": { "type": "integer", "minimum": 320 },
+        "height": { "type": "integer", "minimum": 320 },
+        "fps": { "type": "integer", "enum": [24, 25, 30, 50, 60] },
+        "name": { "type": "string" }
+      }
+    },
+
+    "duration": {
+      "description": "Total seconds. Solved, not asserted — the timing solver writes this back.",
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "maximum": 120
+    },
+
+    "motifs": {
+      "description": "The motif budget: one dominant, two supporting, one surprise, one quiet moment. Enforced mechanically so a concept cannot dissolve into generic motion.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dominant"],
+      "properties": {
+        "dominant": { "type": "string", "minLength": 3 },
+        "supporting": { "type": "array", "maxItems": 3, "items": { "type": "string" } },
+        "surprise_scene": { "type": "string" },
+        "quiet_scene": { "type": "string" }
+      }
+    },
+
+    "objects": {
+      "description": "Things that persist across scenes. An object that appears in one scene only is still an object if it carries meaning.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/object" }
+    },
+
+    "scenes": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "$ref": "#/$defs/scene" }
+    },
+
+    "seams": {
+      "description": "One row per cut. Compiles directly to ledger.json, which motion-doctrine's seam gate verifies numerically.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/seam" }
+    },
+
+    "audio": { "$ref": "#/$defs/audio" }
+  },
+
+  "$defs": {
+    "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9_-]*$", "maxLength": 48 },
+
+    "object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "importance"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "kind": {
+          "enum": ["surface", "text", "figure", "mark", "cursor", "packet", "chrome", "media"]
+        },
+        "label": { "type": "string" },
+        "importance": {
+          "description": "1 is decorative, 5 is the thing the video exists to show. Drives the variant layout solve and what survives a shorter cut.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "content_ref": {
+          "description": "What fills it: a verbatim_copy id, a proof id, or a capture id.",
+          "type": "string"
+        },
+        "layout": { "$ref": "#/$defs/layout" }
+      }
+    },
+
+    "layout": {
+      "description": "Framing intent, not CSS. The variant solver reads this; HyperFrames still owns the actual box.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "preferred_position": {
+          "enum": ["center", "upper", "lower", "leading", "trailing", "full_bleed", "inset"]
+        },
+        "landscape": { "enum": ["primary", "beside", "background", "omit"] },
+        "portrait": { "enum": ["primary", "stacked", "depth", "background", "omit"] },
+        "crop_tolerance": {
+          "description": "Fraction of the object that may leave frame before meaning is lost.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 0.5
+        },
+        "min_readable_px": {
+          "description": "Smallest type size at which this still reads, at the graph's own resolution.",
+          "type": "number",
+          "minimum": 8
+        },
+        "safe_area": { "type": "boolean" }
+      }
+    },
+
+    "scene": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "purpose", "duration"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "title": { "type": "string" },
+
+        "purpose": {
+          "description": "Why this scene exists. A scene that cannot state its purpose is a scene that should be cut.",
+          "type": "string",
+          "minLength": 10,
+          "maxLength": 240
+        },
+        "role": {
+          "description": "Maps to the HyperFrames storyboard roles so blueprint selection can be checked.",
+          "enum": ["Hook", "Problem", "Product_Intro", "Key_Feature", "Benefits", "Social_Proof", "CTA", "Brand_Outro"]
+        },
+
+        "duration": { "type": "number", "exclusiveMinimum": 0, "maximum": 30 },
+        "start": { "type": "number", "minimum": 0 },
+
+        "camera": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "start": { "type": "string" },
+            "end": { "type": "string" },
+            "path": { "type": "string" },
+            "depth_layers": { "type": "integer", "minimum": 1, "maximum": 8 }
+          }
+        },
+
+        "objects": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id"],
+            "properties": {
+              "id": { "$ref": "#/$defs/id" },
+              "start_state": { "type": "string" },
+              "end_state": { "type": "string" },
+              "focal": { "type": "boolean" }
+            }
+          }
+        },
+
+        "required_proof": {
+          "description": "proof ids this scene must actually show. The fidelity check fails if the rendered frame does not contain them.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+
+        "reading": {
+          "description": "What a viewer must be able to read here, and how long that takes. The timing solver treats these as hard constraints, not hints.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["text"],
+            "properties": {
+              "text": { "type": "string", "minLength": 1 },
+              "verbatim_ref": { "type": "string" },
+              "min_reading_s": { "type": "number", "minimum": 0.2 },
+              "settled_by": { "type": "number", "minimum": 0 }
+            }
+          }
+        },
+
+        "motion": {
+          "description": "Cited HyperFrames rule and blueprint ids. Validated against the installed pack; invented names are rejected.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "blueprint": { "type": "string" },
+            "rules": { "type": "array", "items": { "type": "string" }, "maxItems": 4 },
+            "intent": { "type": "string" }
+          }
+        },
+
+        "audio_event": { "type": "string" },
+        "motif": { "type": "string" },
+        "continuity_from": { "type": ["string", "null"] },
+        "continuity_to": { "type": ["string", "null"] },
+        "quiet": {
+          "description": "Marks the deliberate quiet moment. Exempt from the keeps-moving assertion.",
+          "type": "boolean"
+        }
+      }
+    },
+
+    "seam": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to", "at", "vector"],
+      "properties": {
+        "from": { "$ref": "#/$defs/id" },
+        "to": { "$ref": "#/$defs/id" },
+        "at": { "type": "number", "minimum": 0 },
+        "technique": {
+          "description": "A transition name from the installed registry, or a hand-authored morph.",
+          "type": "string"
+        },
+        "vector": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["axis", "direction"],
+          "properties": {
+            "axis": { "enum": ["x", "y", "z"] },
+            "direction": { "enum": ["left", "right", "up", "down", "in", "out"] },
+            "scale_sign": { "enum": ["grow", "shrink", "none"] },
+            "travel_px": { "type": "number", "minimum": 0 }
+          }
+        },
+        "carrier": {
+          "description": "Intent: the object meant to be handed across this cut. Recorded for whoever builds the frames.",
+          "type": "string"
+        },
+        "carrier_out": {
+          "description": "The element id in the outgoing scene. Only when both sides are named does the ledger assert a carrier, because the seam gate measures whether the two really line up.",
+          "type": "string"
+        },
+        "carrier_in": {
+          "description": "The element id in the incoming scene.",
+          "type": "string"
+        },
+        "beat_locked_to": { "type": "number", "minimum": 0 }
+      }
+    },
+
+    "audio": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "music": { "type": ["string", "null"] },
+        "music_volume": { "type": "number", "minimum": 0, "maximum": 1 },
+        "cue_source": { "type": ["string", "null"] },
+        "strong_cue_locks": {
+          "description": "At most three per video. More than that and the edit is following the music instead of the story.",
+          "type": "array",
+          "maxItems": 3,
+          "items": { "type": "number", "minimum": 0 }
+        },
+        "silent_comprehension": {
+          "description": "Whether the story must survive with sound off. True for feed autoplay.",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/schemas/selected_concept.schema.json
+++ b/schemas/selected_concept.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "brag/selected_concept",
+  "title": "Locked concept",
+  "description": "Once chosen, a concept stops being a suggestion and becomes a constraint. Every later stage is checked against it, which is what stops an implementation drifting back into another typography video.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "id", "name", "central_metaphor", "visual_rule", "emotional_arc", "forbidden_motifs", "selection"],
+  "properties": {
+    "schema": { "const": "brag.selected_concept/1" },
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "premise": { "type": "string" },
+    "central_metaphor": { "type": "string" },
+    "visual_rule": { "type": "string" },
+    "emotional_arc": { "type": "string" },
+    "forbidden_motifs": { "type": "array", "items": { "type": "string" } },
+    "suggested_world": { "type": "string" },
+    "beats": { "type": "array" },
+    "why_this_product": { "type": "string" },
+    "risk": { "type": "string" },
+
+    "selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "rated", "computed", "runners_up"],
+      "properties": {
+        "total": { "type": "number" },
+        "rated": { "type": "object" },
+        "computed": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "novelty": { "type": "number" },
+            "difference_from_previous": { "type": "number" }
+          }
+        },
+        "runners_up": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" },
+              "total": { "type": "number" },
+              "worth_grafting": { "type": "string" }
+            }
+          }
+        },
+        "selected_at": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/visual_world.schema.json
+++ b/schemas/visual_world.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "brag/visual_world",
+  "title": "Visual world",
+  "description": "How the product should physically exist on screen. A tone preset governs what the copy says; a world governs camera, depth, materials, and where content sits. Worlds are data rather than prose because the composition reads them directly — a world that does not change the rendered frame is a name, not a look.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "id", "name", "summary", "camera_model", "depth_levels", "transition_families", "layouts"],
+  "properties": {
+    "schema": { "const": "brag.visual_world/1" },
+    "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+    "name": { "type": "string", "minLength": 3 },
+    "summary": { "type": "string", "minLength": 20, "maxLength": 400 },
+
+    "camera_model": {
+      "description": "How the frame moves. Only the documented CSS-perspective camera is supported; three.js is deliberately excluded because it cannot infer a duration and heavy WebGL is out of scope upstream.",
+      "enum": ["locked", "planar-drift", "perspective-flight", "orbit", "scroll", "push"]
+    },
+    "depth_levels": { "type": "integer", "minimum": 1, "maximum": 5 },
+    "transition_families": {
+      "description": "Seam vocabulary this world may spend. At least two, so a film in this world cannot be built from a single move.",
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "items": { "enum": ["slide", "zoom", "morph", "mask", "cut", "rotate", "dissolve"] }
+    },
+
+    "motion_intensity": { "enum": ["restrained", "moderate", "energetic"] },
+
+    "background": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "enum": ["flat", "grid", "gradient", "panel", "rule", "vignette"] },
+        "detail": { "type": "string" }
+      }
+    },
+
+    "typography": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "display_scale": { "type": "number", "minimum": 0.5, "maximum": 2 },
+        "case": { "enum": ["sentence", "upper", "title"] },
+        "lead_family": { "enum": ["sans", "mono"] },
+        "measure": { "type": "integer", "minimum": 400, "maximum": 1800 }
+      }
+    },
+
+    "layouts": {
+      "description": "The compositions this world can put on screen. Scenes rotate through them, which is what stops every frame being the same picture with different words.",
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "align", "anchor"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+          "align": { "enum": ["leading", "center", "trailing"] },
+          "anchor": {
+            "description": "Where the content block sits vertically. Nothing may anchor into the caption band.",
+            "enum": ["top", "upper", "middle", "lower", "split"]
+          },
+          "scale": { "type": "number", "minimum": 0.5, "maximum": 1.8 },
+          "inset": { "type": "number", "minimum": 0.02, "maximum": 0.25 },
+          "chrome": { "enum": ["none", "panel", "rule", "frame"] },
+          "best_for": {
+            "type": "array",
+            "items": { "enum": ["Hook", "Problem", "Product_Intro", "Key_Feature", "Benefits", "Social_Proof", "CTA", "Brand_Outro"] }
+          }
+        }
+      }
+    },
+
+    "avoid": { "type": "array", "items": { "type": "string" } },
+    "suits_surfaces": {
+      "type": "array",
+      "items": { "enum": ["website", "cli", "library", "api", "desktop", "mobile", "game", "hardware", "research"] }
+    }
+  }
+}

--- a/skills/brag/SKILL.md
+++ b/skills/brag/SKILL.md
@@ -166,7 +166,7 @@ controls it. Readability outranks the beat, always.
 
 Everything lands under `brag/` in the project: the product model, captures,
 compositions, renders, reviews, and `brag/delivery/` with the video, its poster
-baked as frame zero, and share copy. Add `brag/` to the project's gitignore —
+attached as cover art, and share copy. Add `brag/` to the project's gitignore —
 captures hold whatever the product printed when it ran.
 
 ## When something fails

--- a/skills/brag/SKILL.md
+++ b/skills/brag/SKILL.md
@@ -1,173 +1,182 @@
 ---
 name: brag
-description: Turn the current project website into a short, polished, shareable launch video using Hyperframes. Use when someone says "/brag", "let's brag about this", "make a launch video", "turn this into a video", or wants to share what they built. Reads the project code directly — no live URL or screenshots needed.
+description: You built it. Now brag. Turn the project you just shipped into a short, shareable launch video with one command. Use when someone says "/brag", "let's brag about this", "make a launch video", "turn this into a video", or wants to share what they built. Reads the project code directly — no live URL or screenshots needed.
 ---
 
 # /brag
 
 You built it. Now let's brag about it.
 
-## Invocation dispatch (must happen first)
+`/brag` turns the current project into a short, polished, shareable launch
+video. It is narrow, opinionated, and fun.
 
-Before inspecting the project, parse the complete `/brag` invocation. If the
-invocation contains `--voice`, set `voice.enabled = true`. Enable narration
-only for that run. Do not enable narration automatically and do not fall back
-to the normal no-voice workflow.
-
-`/brag` turns the current project website or app into a short, polished, shareable launch video using Hyperframes. It is narrow, opinionated, and fun.
-
-## What this skill does
-
-1. Reads the current project code to understand the app.
-2. Plans a short brag concept specific to this project.
-3. Scripts and storyboards the video.
-4. Hands a focused composition brief to Hyperframes.
-5. Validates, renders, and writes share copy.
-
-## Parsing the invocation
-
-The user may invoke with natural language or flags:
+**It is still one command.** Run `/brag` and it goes all the way to a finished
+video. Everything below describes what happens underneath so you can steer it
+when you want to — it is not a checklist for the user to type.
 
 ```
 /brag
 /brag --tone chaotic
-/brag --tone polished --format vertical
+/brag --format vertical
 /brag this. Make it feel like a ridiculous startup launch.
 ```
-
-Parse these options:
 
 | Option | Values | Default |
 |---|---|---|
 | `--tone` | preset or freeform description | inferred |
 | `--format` | `landscape`, `vertical`, `square` | `landscape` |
 | `--duration` | seconds | auto (15-25s) |
-| `--no-music` | flag | music on |
-| `--no-sfx` | flag | sfx on |
-| `--title` | string | inferred from project |
-| `--voice` | flag | narration off |
+| `--no-music` / `--no-sfx` | flag | on |
+| `--title` | string | inferred |
 
-Voice is opt-in. If `--voice` is present, use Kokoro via Hyperframes and do
-not add any provider-selection logic. The voice workflow is intentionally
-single-provider in this PR.
+Tone can be a preset (`default`, `polished`, `yc-parody`, `chaotic`, `deadpan`,
+`cinematic`, `app-store`) or a direction like "fake Series A launch from 2016".
+Freeform direction maps to the nearest preset for pacing and is carried through
+verbatim so it still shapes the writing. Full definitions:
+[references/tones.md](references/tones.md).
 
-Tone can be a preset (`default`, `polished`, `yc-parody`, `chaotic`, `deadpan`, `cinematic`, `app-store`) or a creative direction such as "fake Series A launch from 2016", "museum exhibit", or "overproduced mobile game ad".
+## How to run it
 
-When the user gives freeform tone direction, map it to the nearest preset for pacing and structure, but preserve the user's direction in the plan and composition brief.
+The pipeline is a CLI. **You** drive it; the user does not.
 
-## Narration guidance
-
-When `--voice` is enabled, write narration that complements the visuals, does
-not simply read visible text, matches scene pacing, sounds natural and
-conversational, and moves smoothly between scenes. Keep the script concise and
-specific to the product so the voice feels like part of the edit rather than a
-separate narration track.
-
----
-
-## Output directory
-
-By default, output goes to `brag-output/`. To avoid overwriting previous runs, use a timestamped directory:
-
-```
-brag-output-2026-05-04-143022/
+```bash
+node "$CLAUDE_PLUGIN_ROOT/cli/brag.mjs" doctor
 ```
 
-Use a timestamp when:
-- The user explicitly asks for a new run without overriding previous results
-- A `brag-output/` directory already exists in the project
+Then walk the stages. Each either does its work outright or writes a task spec
+for you to answer:
 
-Generate the timestamp at the start of the run (`YYYY-MM-DD-HHmmss`) and use it consistently for all output paths in that run: plan, brief, composition, render, and share copy.
+```bash
+brag init            # create brag/ in the project
+brag inspect --emit  # → read the spec, write the JSON it asks for
+brag inspect --accept
+brag position --emit     …  brag position --accept
+brag concepts --emit     …  brag concepts --accept
+brag select              # scores and locks one; `brag select <id>` to choose by hand
+brag storyboard --emit   …  brag storyboard --accept
+brag capture             # propose a capture plan; --run once the user approves
+brag compose             # compile, then check + seam gate
+brag deliver             # render, poster, share copy
+brag review              # the verification layers
+```
 
----
+`brag status` says what is done and what is next, derived from artifacts on
+disk — so a run that died halfway resumes truthfully.
 
-## Step 1: Inspect the project
+**The contract:** the CLI never asks you to *do* something inline. It writes a
+spec with an inlined JSON Schema and an output path; you write that file; the
+`--accept` form validates it and recomputes whatever it can compute itself.
+Non-zero exit is the only success signal. Never work around a gate — a gate
+that fails has found something.
 
-**Read:** [references/step-1-inspect.md](references/step-1-inspect.md)
+## What the stages are for
 
-Scan the project directory and extract the information needed to plan the brag video.
+**Inspect.** Classify the product surface before reading it: `website`, `cli`,
+`library`, `api`, `desktop`, `mobile`, `game`, `hardware`, `research`, `mixed`.
+Each gets its own reading. For a CLI the terminal *is* the product interface,
+not supporting material; the same holds for an API and its exchange, and a
+library and its call site. A deterministic scan supplies file signals,
+extracted strings with byte offsets, real git history and the real palette —
+you supply only what a scan cannot decide. Every claim carries a source, and
+`--accept` re-checks each against the filesystem.
 
-**Gate:** You can answer all 9 questions in the brag planning rubric.
+**Position.** Audience, the one sentence the video argues, and every claim
+bound to a proof id. A claim with no proof is dropped, not softened.
 
----
+**Concepts.** At least three genuinely different films, then one is locked.
+Going straight from inspection to a single storyboard produces the same video
+every time. Distinctness is measured, so three descriptions of one film are
+rejected. Scoring runs separately from generation, and novelty is computed
+rather than self-rated. Once locked, the concept is a constraint — its
+forbidden motifs are enforced at compile time.
 
-## Step 2: Plan and storyboard
+**Direct.** A visual world decides how the product physically exists on screen:
+camera model, depth, transition vocabulary, typography, and a set of layouts
+that scenes rotate through. Worlds live in `worlds/` as data, and two declaring
+the same camera × depth × transition triple are rejected — fifteen names for
+three looks is how a catalogue like this rots.
 
-**Read:** [references/step-2-plan.md](references/step-2-plan.md)
+**Storyboard.** A connected scene graph, not a list of slides: purpose, the
+proof each scene must show, what has to be readable, continuity edges, and one
+seam per cut carrying an axis and direction.
 
-Write `<output-dir>/brag-plan.md` (where `<output-dir>` is `brag-output/` or the timestamped variant chosen above). Answer the planning rubric. Commit to a creative angle. Write the beat-by-beat storyboard including scenes, text, timing, transitions, and SFX cues.
+**Capture.** Record the real surface. For a CLI that means running the real
+command and keeping the byte stream, replayed through a terminal emulator so
+carriage returns and line erasure — spinners, progress bars — survive intact.
+Commands are never inferred and run: propose a plan, let the user approve it,
+then run it. Secrets are redacted before anything touches disk.
 
-When music is selected, include a compact `Music cue guidance` section: read the bundled track's cue preset from `assets/music/cues/` if present, otherwise note cues will be detected at composition time (any track now supports beat sync — see `references/audio.md`). Cue metadata is optional timing guidance only: story, readability, pacing, and product clarity stay primary.
+**Compose.** The scene graph compiles into the artifacts HyperFrames already
+reads — `BRIEF.md`, `STORYBOARD.md`, `frame.md`, `ledger.json`, and a
+`*.motion.json` sidecar. Nothing invents a parallel format. Seams are described
+as vectors and stamped by motion-doctrine, so they pass its gate by
+construction. Timing is solved, not asserted.
 
-**Gate:** `<output-dir>/brag-plan.md` exists with a full storyboard. Scene durations sum to 15–25 seconds.
+**Review.** Four layers — structural, visual, narrative and product fidelity.
+`hyperframes check` passing does not mean the video is right; that is the whole
+reason the other three exist.
 
----
-
-## Step 3: Hand off to Hyperframes
-
-**Read:** The Hyperframes domain skills — `hyperframes-core`, `hyperframes-animation`, `hyperframes-creative`, `hyperframes-keyframes`, `hyperframes-cli`. /brag is its own workflow: do not enter the `hyperframes` entry-point intent interview or route into its generic promo / launch-video workflow.
-**Read:** [references/step-3-compose.md](references/step-3-compose.md)
-**Read:** [references/audio.md](references/audio.md)
-
-Write the composition brief and use Hyperframes to create the video implementation in `<output-dir>/composition/`.
-
-`/brag` owns the product angle, source material, storyboard, tone, format, audio selection, music cue guidance, and delivery expectations. Hyperframes owns the concrete composition structure, exact animation timing, animation mechanics, runtime choices, linting rules, and render workflow.
-
-**Gate:** `npx hyperframes check` passes with zero errors inside `<output-dir>/composition/` (the single browser gate before render — see hyperframes-cli for what it audits).
-
----
-
-## Step 4: Validate, render, and deliver
-
-**Read:** [references/step-4-deliver.md](references/step-4-deliver.md)
-
-Validate, preview, render to `<output-dir>/brag.mp4`, pick the best poster frame into `<output-dir>/brag.jpg`, bake that poster as the video's frame 0 so it's the idle thumbnail everywhere, and write `<output-dir>/share-copy.txt`.
-
-**Gate:** `<output-dir>/brag.mp4` exists. A best-frame poster `<output-dir>/brag.jpg` is picked (not an arbitrary frame) and baked as frame 0 of `brag.mp4`. Share copy is written.
-
----
-
-## Tone system
-
-Seven tone presets ship with `/brag`. Each changes scripting energy, pacing, typography personality, and transition style. Presets are defaults, not limits.
-
-Full definitions: [references/tones.md](references/tones.md)
-
-| Tone | Energy | One-liner |
-|---|---|---|
-| `default` | Playful, clean, postable | The good-vibes default |
-| `polished` | Serious, elegant | For projects that are not jokes |
-| `yc-parody` | Deadpan startup energy | Fake seriousness applied to absurd projects |
-| `chaotic` | Fast, loud, aggressive | Over-the-top and unhinged |
-| `deadpan` | Calm, dry, understated | The joke is that nothing is a joke |
-| `cinematic` | Dramatic, trailer-scale | Big motion, bigger claims |
-| `app-store` | Smooth, feature-card clean | Corporate but not boring |
-
-Always allow a freeform creative direction to refine or override the preset.
-
----
+**Variants.** `brag variant vertical` re-solves the same graph for another
+shape. A variant is a recompile, never a re-cut: framing and density change,
+the argument does not.
 
 ## Creative laws
 
-These apply to every brag video regardless of tone.
+These hold whatever the tone.
 
 **Short.** 15–25 seconds. Not one second more without a reason.
 
-**Readable.** Keep the pace high through motion and cuts, never by flashing text. Every line a viewer must read holds long enough to read it (short label ~0.8s settled; a sentence ~0.3s per word). Fast-in, then hold — never fast-in, then gone.
+**Readable.** Pace comes from motion and cuts, never from pulling text away
+before it can be read. A short label needs about 0.8s settled; a sentence about
+0.3s per word. Fast in, then hold. The timing solver enforces this and refuses
+an edit that cannot fit its own copy — when it does, cut copy rather than a
+floor.
 
-**Specific.** The video must feel like it was made for this exact project, not any project.
+**Specific.** It must feel made for this exact project, not any project.
 
-**Show the thing.** At least one scene must display actual UI, copy, or a key visual from the product. No abstract filler.
+**Show the thing.** At least one scene shows real UI, real copy, or a real
+captured surface. No abstract filler.
 
-**No generic SaaS language.** "Streamline your workflow" is banned. Use the project's actual copy and claims.
+**Sourced.** Everything on screen resolves to something the project actually
+says or prints. The fidelity layer checks this, and it is the difference
+between a launch video that is persuasive and one that is defensible.
 
-**The hook is everything.** The first 2 seconds determine whether someone keeps watching. Plan the hook before anything else.
+**No generic SaaS language.** "Streamline your workflow" is banned.
 
-**Funny earns its place.** Humor should come from the project's absurdity, not from trying to be funny.
+**The hook is everything.** The first two seconds decide whether anyone sees
+the third. Plan it before anything else.
 
-**Pattern:**
+**Funny earns its place.** Humour comes from the product's own absurdity, not
+from trying to be funny.
+
 ```
-Hook (2-3s) → Reveal (2-4s) → 2-3 sharp highlights (5-12s) → Punchline/outro (2-4s)
+Hook (2-3s) → Reveal (2-4s) → 2-3 sharp highlights (5-12s) → Punchline (2-4s)
 ```
 
-Adapt this. Not every project needs exactly 3 highlights. The pattern is a starting shape, not a template.
+Adapt it. It is a starting shape, not a template.
+
+## Audio
+
+Default posture is music on, SFX sparse and motion-matched. Track choices, the
+SFX library, cue sources and the volume policy are in
+[references/audio.md](references/audio.md). Cue metadata biases timing; it never
+controls it. Readability outranks the beat, always.
+
+## Output
+
+Everything lands under `brag/` in the project: the product model, captures,
+compositions, renders, reviews, and `brag/delivery/` with the video, its poster
+baked as frame zero, and share copy. Add `brag/` to the project's gitignore —
+captures hold whatever the product printed when it ran.
+
+## When something fails
+
+Read the message. Every gate names what it found and where:
+
+- *"the edit does not fit its own copy"* — cut a line; the reading floor does
+  not move.
+- *"this video is too much like the ones before it"* — pick a different visual
+  world, or a concept that needs a different kind of frame.
+- *"appears on screen with nothing behind it"* — source the line or cut it.
+- *"a scene describes X, which the locked concept forbids"* — the
+  implementation drifted back toward the generic version of itself.

--- a/skills/brag/references/step-4-deliver.md
+++ b/skills/brag/references/step-4-deliver.md
@@ -56,19 +56,22 @@ ffmpeg -ss 3.2 -i ../brag.mp4 -frames:v 1 -q:v 2 ../brag.jpg
 
 Aim for a frame that's postable on its own (the "show the thing" law — any frozen frame should be shareable). If the pulled frame lands on a transition or mid-animation, nudge the timestamp a few tenths of a second and re-extract.
 
-### Bake the poster as frame 0
+### Attach the poster, and make the opening earn frame 0
 
-A bare `.mp4` has no `poster` attribute — every player and platform picks its own idle thumbnail, and almost all of them grab **frame 0**. Slack, Twitter/X, and Discord regenerate thumbnails server-side and ignore embedded cover-art metadata, so the *only* reliable way to control the idle image everywhere is to make frame 0 *be* the poster.
+A bare `.mp4` has no `poster` attribute, so a player picks its own idle image and most thumbnail grabbers take **frame 0**. The tempting fix is to paint the poster over the first frame.
 
-Replace **only** the first frame's pixels with `brag.jpg`, leaving every other frame and all timing untouched — same duration, same frame count, audio copied through. At 30fps the poster shows for 1/30s before the intro rolls, so it's imperceptible on playback but it's what every thumbnail grabber sees. From `brag-output`:
+Don't. Frame 0 is what a player shows while the video sits paused — so a spliced poster is the image the viewer stares at *and then* watches jump to something else the instant they press play. It is one frame, and it reads as a glitch rather than as a thumbnail. A blind reviewer called it exactly that on a film that had passed every other gate. "Imperceptible on playback" is not true of the frame a paused video is parked on.
+
+So the poster is attached as an `attached_pic` stream — what players and metadata readers look for — copying the streams rather than re-encoding, which also means delivery cannot degrade the render:
 
 ```bash
 ffmpeg -y -i brag.mp4 -i brag.jpg \
-  -filter_complex "[0:v][1:v]overlay=0:0:enable='eq(n,0)'[v]" \
-  -map "[v]" -map 0:a? -c:v libx264 -crf 18 -preset slow -pix_fmt yuv420p \
-  -c:a copy -movflags +faststart brag.poster.mp4 \
+  -map 0 -map 1 -c copy -c:v:1 mjpeg \
+  -disposition:v:1 attached_pic -movflags +faststart brag.poster.mp4 \
   && mv brag.poster.mp4 brag.mp4
 ```
+
+That leaves the platforms which regenerate thumbnails server-side taking frame 0, and the honest answer to those is an opening worth grabbing rather than a splice. The flat-frame detector fails a frame zero that is black or empty for exactly this reason: if the hook opens on a blank background mid-fade, fix the hook.
 
 The poster (`brag.jpg`) matches the video's dimensions because it was pulled from the same render, so the overlay lines up exactly. Keep `brag.jpg` alongside — it's the custom-thumbnail asset for platforms that accept an upload (Instagram, TikTok, YouTube, Facebook, and the LinkedIn post editor) and the `poster="brag.jpg"` image for any `<video>` that embeds the brag (a gallery card, the user's site).
 

--- a/skills/brag/sub-agents/frame-worker.md
+++ b/skills/brag/sub-agents/frame-worker.md
@@ -1,0 +1,87 @@
+# Frame worker — brag delta
+
+You are building one frame of a launch video for a real, working product. The
+core contract above holds in full. This adds what is specific to brag.
+
+## What is different here
+
+**There is no narration.** Brag films are usually silent, and there is no
+caption track. So the constraint that visible text must be a hero word rather
+than a sentence is *relaxed* — your frame's reading lines ARE the voice, and
+they must be legible and held. The block quoted under **Must be readable
+here** in your storyboard block is copy the film has committed to: render it
+exactly, and let it settle for at least the stated time.
+
+Everything else about text still applies: nothing else on screen should be a
+paragraph, and the reading lines are the only sentences in the frame.
+
+**Captions are disabled, and the keep-out still holds.** Keep every element
+above `y ≈ 0.83 × height`. It is a bottom-edge consistency rule, not a caption
+rule, and a review layer measures it from rendered pixels.
+
+## Fill the frame
+
+This is the one that gets failed most, and in portrait it gets failed worst.
+A single line of type floating in the middle of a 1080×1920 canvas is not a
+composition — it is a placeholder that survived to the render.
+
+- Anchor the hero high, around `0.2–0.35 × height`, and let supporting
+  material flow down from it.
+- Compose the whole region above the keep-out. If you have one line of copy,
+  the frame needs something else in it: the product surface, a structural
+  element the world calls for, a figure, the object the scene is about.
+- Scale the hero toward full-bleed rather than setting it at body size in the
+  middle of an empty page.
+
+## Build what the world says exists
+
+`frame.md` carries a **visual world** — a camera model, a number of depth
+levels, and a transition vocabulary. These are not decoration and they are not
+optional. A world that declares `camera_model: push` and `depth_levels: 5`
+describes a frame with real depth in it: a `perspective` lens on the stage, a
+`preserve-3d` world, and elements sitting on distinct Z planes that the camera
+moves through. If your frame renders as flat type on a flat page, you have not
+built the world — you have ignored it.
+
+Use the documented CSS-perspective camera (`hyperframes-animation`'s
+`3d-camera-flight` rule). Three.js is out of scope.
+
+## brag's own storyboard fields
+
+Your block carries `brag_*` keys alongside the standard ones. They are the
+scene graph speaking:
+
+- `brag_scene_id` — the scene's id in the graph. Prefix your authored ids and
+  class names with the frame id, as the core contract requires.
+- `brag_role` — how the storyboard files this scene: `Hook`, `Problem`,
+  `Product_Intro`, `Key_Feature`, `Benefits`, `Social_Proof`, `CTA`,
+  `Brand_Outro`. **Never render it.** It is brag's filing system, and a frame
+  that prints `SOCIAL PROOF` on itself both leaks internal vocabulary and makes
+  a claim about third parties that the frame usually cannot support.
+- `brag_objects` — the objects this scene shows, with the focal one starred.
+  The starred object is the hero; build the frame around it.
+- `brag_proof` — the proof id this scene is required to show. If it is present,
+  the frame must *show* that evidence, not assert it in a sentence.
+- `brag_continuity_in` / `brag_continuity_out` — the neighbouring scenes. What
+  travels across those cuts is stamped at the root; you do not author it.
+- `brag_start` — where this frame sits on the film's clock, for reference.
+
+## Captured surfaces are real, and they are the point
+
+If your dispatch names a capture (a terminal session, a screenshot, an API
+exchange), it holds bytes the product actually produced. Render it as the
+product's own interface, at a size someone can read — for a CLI the terminal
+*is* the product, not evidence pasted onto a slide.
+
+Never hand-write terminal output, invent a log line, or extend a captured
+session with plausible-looking rows. A verification layer compares every
+rendered string against the capture and against the product model, and an
+invented line fails it as capture drift.
+
+## Everything on screen must be sourced
+
+Any string you render has to trace to something the project actually says or
+prints: a verbatim string from the product model, a line from a capture, or a
+claim bound to a proof. Do not write connective copy, taglines, feature names,
+or numbers of your own. If a frame feels like it needs a line that does not
+exist, that is a storyboard problem — build what you were given.

--- a/test/capture.test.mjs
+++ b/test/capture.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * Capture: redaction and terminal emulation.
+ *
+ * Redaction is tested hardest because it is the one part of this pipeline
+ * whose failure mode is a credential in a file the user later publishes.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { isClean, redact } from "../cli/lib/capture/redact.mjs";
+import { emulate, sessionText } from "../cli/lib/capture/terminal.mjs";
+
+const chunk = (s, t = 0) => ({ t_ms: t, stream: "out", data: Buffer.from(s, "utf8") });
+
+/* ------------------------------------------------------------------ redaction */
+
+test("provider-shaped credentials are removed", () => {
+  const cases = [
+    "ghp_abcdefghijklmnop0123456789",
+    "sk-ant-api03-aaaaaaaaaaaaaaaaaaaaaaaa",
+    "AKIAIOSFODNN7EXAMPLE",
+    "xoxb-1234567890-abcdefghij",
+  ];
+  for (const secret of cases) {
+    const { text } = redact(`printing ${secret} now`);
+    assert.ok(!text.includes(secret), `${secret} survived redaction`);
+    assert.match(text, /\[redacted\]/);
+  }
+});
+
+test("named secrets in assignments are removed but the key is kept", () => {
+  const { text } = redact('api_key="s3cret-value-here"');
+  assert.ok(!text.includes("s3cret-value-here"));
+  assert.match(text, /api_key=/, "the shape of the line should survive so it still reads as output");
+});
+
+test("credentials inside a connection string go, the user does not", () => {
+  const { text } = redact("postgres://alice:hunter2@db.example.com:5432/app");
+  assert.ok(!text.includes("hunter2"));
+  assert.match(text, /postgres:\/\/alice:\[redacted\]@db\.example\.com/);
+});
+
+test("a bearer header keeps its scheme", () => {
+  const { text } = redact("Authorization: Bearer abcdefghijklmnopqrstuvwxyz");
+  assert.match(text, /Bearer \[redacted\]/);
+});
+
+test("ordinary output is left completely alone", () => {
+  const plain = "2 files written to .tapedeck/\ninstalling... done OK";
+  assert.equal(redact(plain).text, plain);
+  assert.ok(isClean(plain));
+});
+
+test("redaction counts what it removed, by kind", () => {
+  const { hits } = redact("ghp_aaaaaaaaaaaaaaaaaaaa and ghp_bbbbbbbbbbbbbbbbbbbb");
+  const counts = Object.fromEntries(hits);
+  assert.equal(counts.github_token, 2);
+});
+
+/* ------------------------------------------------------------------ emulation */
+
+test("a progress bar rewriting its own line collapses to settled screens", async () => {
+  const states = await emulate(
+    [
+      chunk("installing\r", 0),
+      chunk("installing... 40%\r", 150),
+      chunk("installing... 90%\r", 300),
+      chunk("installing... done\n", 450),
+    ],
+    { geometry: { cols: 40, rows: 5 } },
+  );
+  assert.equal(states.length, 4, "each redraw that persisted is its own state");
+  const last = states.at(-1);
+  assert.equal(last.grid[0].runs.map((r) => r.text).join(""), "installing... done");
+});
+
+test("a redraw too brief to see is dropped", async () => {
+  const states = await emulate(
+    [chunk("one\r", 0), chunk("two\r", 5), chunk("three\n", 400)],
+    { geometry: { cols: 20, rows: 4 } },
+  );
+  assert.ok(states.length < 3, `a 5ms flash should not count as a state (got ${states.length})`);
+});
+
+test("colour is preserved as a styled run", async () => {
+  const states = await emulate([chunk("done \u001b[32mOK\u001b[0m\n")], {
+    geometry: { cols: 20, rows: 3 },
+  });
+  const runs = states.at(-1).grid[0].runs;
+  assert.equal(runs.length, 2, "plain text and coloured text are different runs");
+  assert.equal(runs[0].text, "done ", "the space before a coloured word must survive");
+  assert.equal(runs[1].text, "OK");
+  assert.equal(runs[1].fg, 2);
+});
+
+test("lines start at column zero, as they would on a real tty", async () => {
+  const session = {
+    states: await emulate([chunk("first line\nsecond line\n")], { geometry: { cols: 30, rows: 4 } }),
+  };
+  assert.deepEqual(sessionText(session), ["first line", "second line"]);
+});
+
+test("indentation is rebuilt from column positions", async () => {
+  const session = {
+    states: await emulate([chunk(".tapedeck/\n  session.md\n")], { geometry: { cols: 30, rows: 4 } }),
+  };
+  assert.deepEqual(sessionText(session), [".tapedeck/", "  session.md"]);
+});

--- a/test/compile.test.mjs
+++ b/test/compile.test.mjs
@@ -151,12 +151,27 @@ test("motion assertions never contradict the seam technique", () => {
   assert.equal(moving[0].withinSelector, "#root");
 });
 
-test("every reading line gets an appearsBy assertion at its settled time", () => {
+test("every reading line must appear in time to be read, however it is revealed", () => {
   const motion = buildMotionJson({ graph });
   const appears = motion.assertions.filter((a) => a.kind === "appearsBy" && a.selector.startsWith("#read-"));
   assert.equal(appears.length, 3);
+
+  /* The assertion is the deadline, not the scaffold's own tween schedule: a
+     line has to be up by the last moment that still leaves its reading floor.
+     Pinning it to `settled` failed designed frames that revealed the same
+     line a quarter-second differently and held it far longer than the floor. */
+  const scenes = withStarts(graph);
+  for (const a of appears) {
+    const [, id, index] = a.selector.match(/^#read-(.+)-(\d+)$/);
+    const scene = scenes.find((s) => s.id === id);
+    const line = scheduleReading(scene)[Number(index)];
+    assert.equal(a.bySec, Number((scene.start + scene.duration - line.floor).toFixed(2)));
+    assert.ok(a.bySec < scene.start + scene.duration, "a line cannot first appear after its scene ends");
+  }
+
+  /* A longer line therefore has an EARLIER deadline — it needs more time. */
   const mech = appears.filter((a) => a.selector.startsWith("#read-mechanism-"));
-  assert.ok(mech[0].bySec < mech[1].bySec, "assertions must follow the same order as the composition");
+  assert.ok(mech[1].bySec < mech[0].bySec, "the longer line must be up sooner, not later");
 });
 
 test("the storyboard carries brag's payload under keys the parser preserves", () => {
@@ -202,4 +217,41 @@ test("the schema validator reports the path and the reason, not just a failure",
   assert.equal(errors.length, 2);
   assert.match(errors[0].message, /at least 2 characters/);
   assert.equal(errors[1].path, "count");
+});
+
+/* ----------------------------------------------- designed frames */
+
+test("a scene with a designed frame mounts it instead of the generated scaffold", () => {
+  const world = loadWorlds()[0];
+  const designedFrames = new Map([
+    ["hook", { src: "compositions/frames/01-hook.html", compositionId: "01-hook" }],
+  ]);
+  const html = buildIndexHtml({ model, graph, world, designedFrames });
+
+  /* The host IS the clip: nesting it inside another timed element puts two
+     clips on one track at the same instant, which `check` refuses. */
+  assert.match(
+    html,
+    /<div id="el-hook" class="clip" data-composition-id="01-hook" data-composition-src="compositions\/frames\/01-hook\.html"/,
+  );
+  assert.doesNotMatch(html, /<section id="el-hook"/);
+  assert.match(html, /data-width="1920" data-height="1080"><\/div>/);
+
+  /* The frame owns its own reveals, so the root must not also drive them. */
+  assert.doesNotMatch(html, /#read-hook-0/);
+
+  /* A scene without a designed frame still gets the scaffold. */
+  assert.match(html, /<section id="el-mechanism"/);
+  assert.match(html, /id="read-mechanism-0"/);
+});
+
+test("the film's first line does not fade up from nothing", () => {
+  const world = loadWorlds()[0];
+  const html = buildIndexHtml({ model, graph, world });
+  const first = html.match(/tl\.fromTo\("#read-hook-0", \{ opacity: (\d)/);
+  assert.ok(first, "the opening line should still be tweened");
+  assert.equal(first[1], "1", "frame zero is the thumbnail and the paused-player image");
+
+  const later = html.match(/tl\.fromTo\("#read-mechanism-0", \{ opacity: (\d)/);
+  assert.equal(later[1], "0", "only the film's opening line is exempt");
 });

--- a/test/compile.test.mjs
+++ b/test/compile.test.mjs
@@ -1,0 +1,205 @@
+/**
+ * Phase 1 gate, minus the browser.
+ *
+ * The two slow gates — `hyperframes check` and the seam gate — run in
+ * `brag compose` against a real Chrome. These cover what can be proven without
+ * one, including the two bugs that a render caught rather than a test:
+ * reading lines scheduling out of order, and non-deterministic compiles.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildLedger,
+  buildMotionJson,
+  buildStoryboard,
+  readingFloor,
+  scheduleReading,
+  tightScenes,
+  totalDuration,
+  withStarts,
+} from "../cli/lib/compile/targets.mjs";
+import { buildIndexHtml } from "../cli/lib/compile/composition.mjs";
+import { loadWorlds } from "../cli/lib/worlds.mjs";
+import { normalizeForCompare } from "../cli/lib/determinism.mjs";
+import { validate } from "../cli/lib/schema.mjs";
+
+const model = {
+  name: "Tapedeck",
+  one_line: "Records what your terminal printed.",
+  surface_type: "cli",
+  problem: "A recorded demo drifts.",
+  mechanism: "It captures the byte stream.",
+  proof: [{ id: "byte_identical", claim: "frames replay byte-identical", strength: "measured", evidence: [{ file: "README.md" }] }],
+  visual_surfaces: [{ id: "terminal", kind: "terminal", description: "the session" }],
+  forbidden_claims: [],
+  verbatim_copy: [],
+  identity: {},
+};
+
+const positioning = {
+  audience: { who: "developers who publish demos", destination: ["x"] },
+  angle: "A hand-recorded demo is already out of date.",
+  claims: [{ text: "frames replay byte-identical", proof_ref: "byte_identical" }],
+  action: "npm i -g tapedeck",
+};
+
+const graph = {
+  schema: "brag.scene_graph/1",
+  format: { width: 1920, height: 1080, fps: 30 },
+  objects: [{ id: "line", kind: "text", importance: 4 }],
+  scenes: [
+    {
+      id: "hook",
+      role: "Hook",
+      purpose: "Show the drift.",
+      duration: 4.5,
+      reading: [{ text: "A recorded demo drifts from what the tool really prints." }],
+    },
+    {
+      id: "mechanism",
+      role: "Product_Intro",
+      purpose: "Show the capture.",
+      duration: 5.5,
+      /* A short command followed by a long sentence: the exact shape that
+         used to invert, because the longer line has the longer floor. */
+      reading: [
+        { text: 'tapedeck record "npm test"' },
+        { text: "It captures the byte stream and replays it as data." },
+      ],
+      required_proof: ["byte_identical"],
+    },
+  ],
+  seams: [
+    { from: "hook", to: "mechanism", at: 4.5, technique: "cut-the-curve LEFT", vector: { axis: "x", direction: "left" } },
+  ],
+};
+
+test("reading floor scales with word count and never drops below a readable minimum", () => {
+  assert.equal(readingFloor("Ship"), 0.8);
+  assert.equal(readingFloor("one two three"), 0.8);
+  assert.ok(readingFloor("a line of exactly seven words here") >= 1.8);
+});
+
+test("reading lines schedule in source order, however long each one is", () => {
+  const scene = { ...graph.scenes[1], start: 4.5 };
+  const lines = scheduleReading(scene);
+  assert.equal(lines.length, 2);
+  assert.ok(
+    lines[0].settled < lines[1].settled,
+    `line 0 settles at ${lines[0].settled}, line 1 at ${lines[1].settled} — order inverted`,
+  );
+  assert.ok(lines[0].enter >= scene.start, "a line cannot enter before its scene");
+});
+
+test("the last line still gets its full reading floor", () => {
+  const scene = { ...graph.scenes[1], start: 4.5 };
+  const lines = scheduleReading(scene);
+  const last = lines.at(-1);
+  const end = scene.start + scene.duration;
+  assert.ok(
+    end - last.settled >= last.floor - 0.01,
+    `last line settles at ${last.settled} with ${(end - last.settled).toFixed(2)}s left, needs ${last.floor}s`,
+  );
+});
+
+test("a scene too short for its copy is reported rather than silently reordered", () => {
+  const cramped = {
+    ...graph,
+    scenes: [
+      graph.scenes[0],
+      { ...graph.scenes[1], duration: 1.0 },
+    ],
+  };
+  const tight = tightScenes(cramped);
+  assert.equal(tight.length, 1);
+  assert.equal(tight[0].scene.id, "mechanism");
+});
+
+test("scene starts accumulate and total duration follows", () => {
+  const scenes = withStarts(graph);
+  assert.equal(scenes[0].start, 0);
+  assert.equal(scenes[1].start, 4.5);
+  assert.equal(totalDuration(graph), 10);
+});
+
+test("the ledger names one row per seam with matching exit and entry vectors", () => {
+  const ledger = buildLedger({ graph });
+  assert.equal(ledger.fps, 30);
+  assert.equal(ledger.seams.length, 1);
+  const [row] = ledger.seams;
+  assert.equal(row.exit.selector, "#el-hook");
+  assert.equal(row.entry.selector, "#el-mechanism");
+  assert.equal(row.exit.axis, row.entry.axis);
+  assert.equal(row.exit.dir, row.entry.dir, "a mirrored vector is the seam bug the gate exists to catch");
+});
+
+test("motion assertions never contradict the seam technique", () => {
+  const motion = buildMotionJson({ graph });
+
+  /* staysInFrame has no time window, so in a film whose scenes travel on exit
+     it fails on every non-final scene by design — on the wrapper and on the
+     text alike. Layer 2 answers the real question from rendered pixels. */
+  assert.equal(
+    motion.assertions.filter((a) => a.kind === "staysInFrame").length,
+    0,
+    "staysInFrame cannot coexist with scenes that travel on exit",
+  );
+
+  const moving = motion.assertions.filter((a) => a.kind === "keepsMoving");
+  assert.equal(moving.length, 1, "one frozen-shot check for the film, not one per scene");
+  assert.equal(moving[0].withinSelector, "#root");
+});
+
+test("every reading line gets an appearsBy assertion at its settled time", () => {
+  const motion = buildMotionJson({ graph });
+  const appears = motion.assertions.filter((a) => a.kind === "appearsBy" && a.selector.startsWith("#read-"));
+  assert.equal(appears.length, 3);
+  const mech = appears.filter((a) => a.selector.startsWith("#read-mechanism-"));
+  assert.ok(mech[0].bySec < mech[1].bySec, "assertions must follow the same order as the composition");
+});
+
+test("the storyboard carries brag's payload under keys the parser preserves", () => {
+  const md = buildStoryboard({ graph, positioning, model });
+  assert.match(md, /^## Frame 1 — /m);
+  assert.match(md, /- brag_scene_id: hook/);
+  assert.match(md, /- brag_proof: byte_identical/);
+  assert.match(md, /- duration: 4.5s/);
+  assert.match(md, /format: 1920x1080/);
+});
+
+test("compiling the same graph twice produces identical output", () => {
+  const world = loadWorlds()[0];
+  assert.equal(buildIndexHtml({ model, graph, world }), buildIndexHtml({ model, graph, world }));
+});
+
+test("a different world composes the same graph differently", () => {
+  const [a, b] = loadWorlds();
+  assert.notEqual(
+    buildIndexHtml({ model, graph, world: a }),
+    buildIndexHtml({ model, graph, world: b }),
+    "a world that does not change the frame is a name, not a look",
+  );
+});
+
+test("determinism comparison ignores the identity attributes HyperFrames injects", () => {
+  const authored = '<div id="root" class="a">x</div>';
+  const opened = '<div data-hf-id="hf-9zzz" id="root" class="a">x</div>';
+  assert.equal(
+    normalizeForCompare("index.html", authored),
+    normalizeForCompare("index.html", opened),
+  );
+});
+
+test("the schema validator reports the path and the reason, not just a failure", () => {
+  const schema = {
+    type: "object",
+    required: ["id", "count"],
+    properties: { id: { type: "string", minLength: 2 }, count: { type: "integer", minimum: 1 } },
+  };
+  const { ok, errors } = validate(schema, { id: "a", count: 0 });
+  assert.equal(ok, false);
+  assert.equal(errors.length, 2);
+  assert.match(errors[0].message, /at least 2 characters/);
+  assert.equal(errors[1].path, "count");
+});

--- a/test/concept.test.mjs
+++ b/test/concept.test.mjs
@@ -1,0 +1,124 @@
+/**
+ * Concept distinctness and selection.
+ *
+ * The two things worth protecting here are that three descriptions of one film
+ * are caught before anyone scores them, and that the model which wrote the
+ * concepts never gets to rate them on originality.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DISTINCTNESS_CEILING,
+  checkDistinct,
+  differenceFromPrevious,
+  novelty,
+  rankConcepts,
+  WEIGHTS,
+} from "../cli/lib/score/concept.mjs";
+
+const concept = (id, over = {}) => ({
+  id,
+  name: id,
+  premise: "A thing happens on screen and then another thing happens.",
+  central_metaphor: "something stands for something else",
+  visual_rule: "the rule is never broken",
+  emotional_arc: "doubt to belief",
+  forbidden_motifs: ["floating cards"],
+  ...over,
+});
+
+const tape = concept("tape", {
+  premise: "The camera travels along a ribbon of terminal output, stopping at moments that matter.",
+  central_metaphor: "the session is a tape you can walk along",
+  visual_rule: "the camera only moves forward along the ribbon",
+});
+const tapeAgain = concept("tape-again", {
+  premise: "The camera travels along a ribbon of terminal output, pausing at moments that matter.",
+  central_metaphor: "the session is a ribbon you can walk along",
+  visual_rule: "the camera only travels forward along the ribbon",
+});
+const witness = concept("witness", {
+  premise: "Each claim is pinned up as evidence with its source attached and the links drawn between them.",
+  central_metaphor: "every claim is an exhibit with provenance",
+  visual_rule: "nothing appears without its source beside it",
+});
+
+const rate = (score) => ({ score, because: "a specific reason naming something in this concept" });
+const scoresFor = (ids, table = {}) =>
+  ids.map((id) => ({
+    concept_id: id,
+    criteria: {
+      product_clarity: rate(table[id]?.product_clarity ?? 3),
+      product_proof: rate(table[id]?.product_proof ?? 3),
+      emotional_strength: rate(table[id]?.emotional_strength ?? 3),
+      platform_fit: rate(table[id]?.platform_fit ?? 3),
+      silent_comprehension: rate(table[id]?.silent_comprehension ?? 3),
+    },
+  }));
+
+test("one concept in two costumes is caught", () => {
+  const result = checkDistinct([tape, tapeAgain, witness]);
+  assert.equal(result.ok, false);
+  assert.equal(result.pairs.length, 1);
+  assert.equal(result.pairs[0].a, "tape");
+  assert.equal(result.pairs[0].b, "tape-again");
+  assert.ok(result.pairs[0].overlap >= DISTINCTNESS_CEILING);
+});
+
+test("genuinely different concepts pass", () => {
+  assert.equal(checkDistinct([tape, witness]).ok, true);
+});
+
+test("novelty rewards the concept least like its own batch", () => {
+  const all = [tape, tapeAgain, witness];
+  assert.ok(
+    novelty(witness, all) > novelty(tape, all),
+    "the outlier should score higher than one of a near-identical pair",
+  );
+});
+
+test("difference from previous is full marks with no history", () => {
+  assert.equal(differenceFromPrevious(tape, []), 5);
+});
+
+test("a concept reusing a past world and motifs scores lower", () => {
+  const history = [{ world: "spatial-terminal", object_motifs: ["ribbon", "terminal"], dominant_layouts: [] }];
+  const reuse = differenceFromPrevious(concept("reuse", { suggested_world: "spatial-terminal" }), history);
+  const fresh = differenceFromPrevious(concept("fresh", { suggested_world: "kinetic-editorial" }), history);
+  assert.ok(reuse < fresh, `reuse ${reuse} should score below fresh ${fresh}`);
+});
+
+test("the CLI adds up the total; the model never rates originality", () => {
+  assert.ok("novelty" in WEIGHTS && "difference_from_previous" in WEIGHTS);
+  const { ranked, winner } = rankConcepts({
+    concepts: [tape, witness],
+    scores: scoresFor(["tape", "witness"], {
+      witness: { product_clarity: 5, product_proof: 5 },
+      tape: { product_clarity: 3, product_proof: 3 },
+    }),
+  });
+  assert.equal(winner.concept.id, "witness");
+  assert.equal(ranked.length, 2);
+  /* Computed values are present and were never supplied by the scorer. */
+  assert.ok(typeof winner.computed.novelty === "number");
+  assert.ok(typeof winner.computed.difference_from_previous === "number");
+});
+
+test("clarity breaks a tie", () => {
+  const { winner } = rankConcepts({
+    concepts: [tape, witness],
+    scores: scoresFor(["tape", "witness"], {
+      tape: { product_clarity: 2, emotional_strength: 5 },
+      witness: { product_clarity: 5, emotional_strength: 2 },
+    }),
+  });
+  assert.equal(winner.concept.id, "witness", "clarity outweighs feeling when the totals are close");
+});
+
+test("an unscored concept fails loudly rather than being skipped", () => {
+  assert.throws(
+    () => rankConcepts({ concepts: [tape, witness], scores: scoresFor(["tape"]) }),
+    /was not scored/,
+  );
+});

--- a/test/fidelity.test.mjs
+++ b/test/fidelity.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * Layer 4: every string on screen resolves to a source, or the review fails.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { checkFidelity, extractRenderedText } from "../cli/lib/detect/fidelity.mjs";
+
+const model = {
+  name: "Tapedeck",
+  one_line: "Keeps the working context around your code.",
+  verbatim_copy: [
+    { id: "tagline", text: "Git keeps the history of your code." },
+    { id: "cmd", text: "tapedeck log" },
+  ],
+  forbidden_claims: ["Tapedeck makes your AI smarter"],
+  proof: [{ id: "recall", claim: "100% correct with the context injected, against 17% with none" }],
+};
+const positioning = { claims: [{ text: "log, diff, blame and restore", proof_ref: "git" }], angle: "An angle." };
+const captureLines = ["C588   2026-05-30 21:00  Fix open GitHub roadmap issues"];
+
+const render = (items) => checkFidelity({ rendered: items, model, positioning, captureLines });
+
+test("a verbatim string resolves", () => {
+  const r = render([{ kind: "copy", text: "Git keeps the history of your code.", id: "a" }]);
+  assert.equal(r.findings.length, 0);
+  assert.equal(r.resolved, 1);
+});
+
+test("a captured line resolves", () => {
+  const r = render([{ kind: "terminal_output", text: captureLines[0], id: null }]);
+  assert.equal(r.findings.length, 0);
+});
+
+test("a proof's own claim resolves", () => {
+  const r = render([
+    { kind: "copy", text: "100% correct with the context injected, against 17% with none", id: "b" },
+  ]);
+  assert.equal(r.findings.length, 0);
+});
+
+test("an invented line is caught", () => {
+  const r = render([{ kind: "copy", text: "Three times faster than every alternative.", id: "c" }]);
+  assert.equal(r.findings.length, 1);
+  assert.equal(r.findings[0].code, "unsourced_copy");
+  assert.equal(r.findings[0].scene, "c");
+});
+
+test("copy wrapped around a real source is flagged more gently", () => {
+  const r = render([
+    { kind: "copy", text: "As they say, Git keeps the history of your code, and that matters.", id: "d" },
+  ]);
+  assert.equal(r.findings[0].code, "paraphrased_source");
+});
+
+test("terminal content nothing printed is capture drift, not just unsourced", () => {
+  const r = render([{ kind: "terminal_output", text: "$ rm -rf /", id: null }]);
+  assert.equal(r.findings[0].code, "capture_drift");
+});
+
+test("a forbidden claim on screen is caught even where it resolves elsewhere", () => {
+  const r = render([{ kind: "copy", text: "Tapedeck makes your AI smarter", id: "e" }]);
+  const codes = r.findings.map((f) => f.code);
+  assert.ok(codes.includes("forbidden_claim_rendered"));
+});
+
+test("kickers are structure, not claims, and are not checked", () => {
+  const r = render([{ kind: "kicker", text: "KEY FEATURE", id: null }]);
+  assert.equal(r.checked, 0);
+  assert.equal(r.findings.length, 0);
+});
+
+test("extraction survives the attributes HyperFrames injects", () => {
+  const html = `
+    <p data-hf-id="hf-1" class="lead" id="read-a-0">Git keeps the history of your code.</p>
+    <p class="line" id="read-a-1">A second line.</p>
+    <p data-hf-id="hf-2" class="kicker">HOOK</p>
+    <span class="tlabel">tapedeck log</span>
+    <div data-hf-id="hf-3" class="trow" style="top:0"><span>C588</span><span> Fix issues</span></div>`;
+  const items = extractRenderedText(html);
+  assert.equal(items.length, 5);
+  assert.equal(items[0].id, "read-a-0");
+  assert.equal(items[0].kind, "copy");
+  assert.equal(items[2].kind, "kicker");
+  assert.equal(items.at(-1).text, "C588 Fix issues");
+});

--- a/test/fidelity.test.mjs
+++ b/test/fidelity.test.mjs
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { checkFidelity, extractRenderedText } from "../cli/lib/detect/fidelity.mjs";
+import { checkFidelity, extractRenderedText, extractRenderedTree } from "../cli/lib/detect/fidelity.mjs";
 
 const model = {
   name: "Tapedeck",
@@ -83,4 +83,67 @@ test("extraction survives the attributes HyperFrames injects", () => {
   assert.equal(items[0].kind, "copy");
   assert.equal(items[2].kind, "kicker");
   assert.equal(items.at(-1).text, "C588 Fix issues");
+});
+
+/* ------------------------------------------- frames as sub-compositions */
+
+test("the whole tree is read, not just the index that mounts it", () => {
+  const index = `<div id="root">
+    <div id="el-hook" class="clip" data-composition-id="01-hook"
+         data-composition-src="compositions/frames/01-hook.html"></div>
+  </div>`;
+  const frame = `<template><div id="root" data-composition-id="01-hook">
+    <p id="read-hook-0" class="hook-lead">frames replay byte-identical</p>
+    <span class="hook-tag">invented label</span>
+  </div></template>`;
+
+  /* Reading only the index found nothing at all and reported "0/0 resolve to
+     a source", which prints as a pass — the worst way for a gate to fail. */
+  assert.equal(extractRenderedText(index).length, 0);
+
+  const tree = extractRenderedTree(index, (src) =>
+    src === "compositions/frames/01-hook.html" ? frame : null,
+  );
+  assert.ok(tree.length >= 2, `expected the frame's copy, got ${tree.length}`);
+  assert.ok(tree.some((t) => t.text === "frames replay byte-identical"));
+  assert.ok(tree.some((t) => t.text === "invented label"));
+});
+
+test("a fragment of a sourced line is sourced; a wrapper around one is not", () => {
+  const model = {
+    verbatim_copy: [{ text: "Nobody told it. It already knew." }],
+    proof: [],
+    forbidden_claims: [],
+  };
+
+  /* A hero line revealed clause by clause arrives as separate elements. */
+  const split = checkFidelity({
+    rendered: [
+      { kind: "copy", text: "Nobody told it.", id: null },
+      { kind: "copy", text: "It already knew.", id: null },
+    ],
+    model,
+  });
+  assert.deepEqual(split.findings, []);
+  assert.equal(split.resolved, 2);
+
+  /* Showing MORE than the source is the case that can invent a claim. */
+  const wrapped = checkFidelity({
+    rendered: [{ kind: "copy", text: "Nobody told it. It already knew. Guaranteed.", id: null }],
+    model,
+  });
+  assert.equal(wrapped.findings.length, 1);
+  assert.equal(wrapped.findings[0].code, "paraphrased_source");
+});
+
+test("punctuation-only chrome is not a claim and is not counted", () => {
+  const r = checkFidelity({
+    rendered: [
+      { kind: "copy", text: "$", id: "prompt" },
+      { kind: "copy", text: "→", id: null },
+    ],
+    model: { verbatim_copy: [], proof: [], forbidden_claims: [] },
+  });
+  assert.deepEqual(r.findings, []);
+  assert.equal(r.checked, 0, "a shell prompt is chrome, not copy to source");
 });

--- a/test/fixtures/narrative/bad-lost.json
+++ b/test/fixtures/narrative/bad-lost.json
@@ -1,0 +1,24 @@
+{
+  "label": "bad",
+  "answers": {
+    "schema": "brag.review_narrative/1",
+    "product": "I could not tell what this is for",
+    "problem": "Something about files, I think",
+    "proof": [],
+    "scenes": [
+      "some text",
+      "more text"
+    ],
+    "unsupported": [
+      "it claims to be fast with nothing behind it"
+    ],
+    "readable": [
+      "the second line went by too quickly"
+    ],
+    "silent": {
+      "yes": false,
+      "because": "nothing on screen explains the idea without narration"
+    },
+    "ending": "nothing is asked"
+  }
+}

--- a/test/fixtures/narrative/bad-misread.json
+++ b/test/fixtures/narrative/bad-misread.json
@@ -1,0 +1,28 @@
+{
+  "label": "bad",
+  "answers": {
+    "schema": "brag.review_narrative/1",
+    "product": "A note-taking app",
+    "problem": "People forget their ideas",
+    "proof": [
+      "a logo"
+    ],
+    "scenes": [
+      "a logo",
+      "some words",
+      "a button",
+      "an ending"
+    ],
+    "unsupported": [
+      "every number shown"
+    ],
+    "readable": [
+      "all of the body copy"
+    ],
+    "silent": {
+      "yes": false,
+      "because": "the frames alone do not make a case"
+    },
+    "ending": "unclear"
+  }
+}

--- a/test/fixtures/narrative/context.json
+++ b/test/fixtures/narrative/context.json
@@ -1,0 +1,44 @@
+{
+  "model": {
+    "name": "Tapedeck",
+    "one_line": "Records what your terminal printed so a demo never drifts.",
+    "problem": "A recorded demo drifts from what the tool really prints.",
+    "proof": [
+      {
+        "id": "byte_identical",
+        "claim": "100% of frames replay byte-identical"
+      },
+      {
+        "id": "two_commands",
+        "claim": "the whole tool is record and play"
+      }
+    ]
+  },
+  "positioning": {
+    "action": "npm i -g tapedeck",
+    "claims": []
+  },
+  "graph": {
+    "scenes": [
+      {
+        "id": "hook",
+        "required_proof": []
+      },
+      {
+        "id": "mechanism",
+        "required_proof": [
+          "two_commands"
+        ]
+      },
+      {
+        "id": "proof",
+        "required_proof": [
+          "byte_identical"
+        ]
+      }
+    ],
+    "audio": {
+      "silent_comprehension": true
+    }
+  }
+}

--- a/test/fixtures/narrative/good-faithful.json
+++ b/test/fixtures/narrative/good-faithful.json
@@ -1,0 +1,24 @@
+{
+  "label": "good",
+  "answers": {
+    "schema": "brag.review_narrative/1",
+    "product": "Tapedeck, a command-line tool for recording terminal demos",
+    "problem": "A recorded demo drifts from what the tool really prints",
+    "proof": [
+      "100% of frames replay byte-identical",
+      "the whole tool is record and play"
+    ],
+    "scenes": [
+      "a demo drifting",
+      "the record command",
+      "the measured result"
+    ],
+    "unsupported": [],
+    "readable": [],
+    "silent": {
+      "yes": true,
+      "because": "the argument is carried by what is on screen"
+    },
+    "ending": "npm i -g tapedeck"
+  }
+}

--- a/test/fixtures/narrative/good-partial-proof.json
+++ b/test/fixtures/narrative/good-partial-proof.json
@@ -1,0 +1,23 @@
+{
+  "label": "good",
+  "answers": {
+    "schema": "brag.review_narrative/1",
+    "product": "Tapedeck, a command-line tool for recording terminal demos",
+    "problem": "A recorded demo drifts from what the tool really prints",
+    "proof": [
+      "100% of frames replay byte-identical"
+    ],
+    "scenes": [
+      "drift",
+      "recording",
+      "result"
+    ],
+    "unsupported": [],
+    "readable": [],
+    "silent": {
+      "yes": true,
+      "because": "the argument is carried by what is on screen"
+    },
+    "ending": "npm i -g tapedeck"
+  }
+}

--- a/test/fixtures/narrative/good-terser.json
+++ b/test/fixtures/narrative/good-terser.json
@@ -1,0 +1,24 @@
+{
+  "label": "good",
+  "answers": {
+    "schema": "brag.review_narrative/1",
+    "product": "Tapedeck",
+    "problem": "demos stop matching what the tool prints",
+    "proof": [
+      "100% of frames replay byte-identical",
+      "the whole tool is record and play"
+    ],
+    "scenes": [
+      "drift",
+      "recording",
+      "the number"
+    ],
+    "unsupported": [],
+    "readable": [],
+    "silent": {
+      "yes": true,
+      "because": "the argument is carried by what is on screen"
+    },
+    "ending": "npm i -g tapedeck"
+  }
+}

--- a/test/narrative.test.mjs
+++ b/test/narrative.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * The narrative grader, measured before it is trusted.
+ *
+ * A stochastic reviewer that has never been scored against known answers has
+ * no business failing a delivery. These fixtures are the measurement: three
+ * reviews written as a viewer who followed the film, two as one who did not.
+ * The confusion matrix they produce is printed, and the threshold is only
+ * defensible for as long as it separates them.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { scoreNarrative } from "../cli/lib/detect/narrative.mjs";
+
+const dir = path.join(import.meta.dirname, "fixtures", "narrative");
+const read = (f) => JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
+const { model, positioning, graph } = read("context.json");
+
+const cases = fs
+  .readdirSync(dir)
+  .filter((f) => f.endsWith(".json") && f !== "context.json")
+  .map((f) => ({ name: f.replace(/\.json$/, ""), ...read(f) }));
+
+/** Agreement at or above this is treated as "followed the film". */
+const THRESHOLD = 0.7;
+
+test("the grader separates a viewer who followed the film from one who did not", () => {
+  const matrix = { tp: 0, fp: 0, tn: 0, fn: 0 };
+  const rows = [];
+
+  for (const c of cases) {
+    const { agreement } = scoreNarrative({ answers: c.answers, model, positioning, graph });
+    const predictedGood = agreement >= THRESHOLD;
+    const actuallyGood = c.label === "good";
+    rows.push({ name: c.name, label: c.label, agreement, predictedGood });
+
+    if (actuallyGood && predictedGood) matrix.tp++;
+    else if (!actuallyGood && predictedGood) matrix.fp++;
+    else if (!actuallyGood && !predictedGood) matrix.tn++;
+    else matrix.fn++;
+  }
+
+  /* Printed on every run, so the number is never a claim in a commit message
+     that has quietly stopped being true. */
+  console.log(`\n  narrative grader, threshold ${THRESHOLD}`);
+  for (const r of rows) {
+    console.log(
+      `    ${r.name.padEnd(20)} labelled ${r.label.padEnd(5)} agreement ${r.agreement.toFixed(2)} → ${r.predictedGood ? "good" : "bad"}`,
+    );
+  }
+  console.log(`    tp ${matrix.tp}  fp ${matrix.fp}  tn ${matrix.tn}  fn ${matrix.fn}\n`);
+
+  const good = cases.filter((c) => c.label === "good").length;
+  const bad = cases.length - good;
+
+  /* A grader that misses a bad review is the dangerous direction: it would
+     wave through a video nobody understood. */
+  assert.equal(matrix.fp, 0, "a review from a lost viewer was scored as good");
+  assert.equal(matrix.tn, bad, "every bad review must be caught");
+  assert.ok(matrix.tp >= good - 1, `only ${matrix.tp}/${good} good reviews recognised`);
+});
+
+test("it stays a report, not a gate, until that matrix is better than this", () => {
+  /* Documented as an assertion so removing the caveat requires removing this
+     test, which is harder to do by accident than editing a comment. */
+  const source = fs.readFileSync(
+    path.join(import.meta.dirname, "..", "cli", "commands", "review.mjs"),
+    "utf8",
+  );
+  assert.match(source, /gating: false/, "the narrative layer must not gate delivery yet");
+});

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -1,0 +1,347 @@
+/**
+ * Phase 2: the timing solver and the layer-2 detectors.
+ *
+ * Detectors are exercised against synthetic frames rather than a render, so a
+ * threshold change shows up as a failing assertion with a number in it instead
+ * of a video someone has to squint at.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  detectCaptionZone,
+  detectFlatFrames,
+  detectRepeatedLayouts,
+  detectUnreadableCopy,
+  layoutSignature,
+} from "../cli/lib/detect/index.mjs";
+import { aHash, hamming, isFlat, rowInk } from "../cli/lib/watch/pixels.mjs";
+import { chooseTimes } from "../cli/lib/watch/bundle.mjs";
+import { minimumDuration, solveTiming } from "../cli/lib/solve/timing.mjs";
+import { tightScenes } from "../cli/lib/compile/targets.mjs";
+import { assignLayouts, assertDistinct, loadWorlds, worldSignature } from "../cli/lib/worlds.mjs";
+import { checkSameness, familyOf, fingerprint, similarity } from "../cli/lib/score/fingerprint.mjs";
+
+/* ------------------------------------------------------------------ helpers */
+
+const frame = (over = {}) => ({
+  at: 3,
+  kind: "midpoint",
+  scene: "hook",
+  hash: "0",
+  ink: new Array(36).fill(0),
+  tone: { flat: false, dark: false, mean: 40, stdDev: 30 },
+  ...over,
+});
+
+/** A synthetic grayscale frame with a band of ink at a given height. */
+function grayWithInkAt(fraction, { w = 64, h = 36, bg = 12, ink = 200 } = {}) {
+  const data = new Uint8Array(w * h).fill(bg);
+  const row = Math.floor(h * fraction);
+  for (let y = row; y < Math.min(h, row + 2); y++) {
+    for (let x = 4; x < w - 4; x++) data[y * w + x] = ink;
+  }
+  return { w, h, data };
+}
+
+/* ------------------------------------------------------------------ timing */
+
+test("a scene's minimum duration accounts for entry, stagger and the last line's floor", () => {
+  const min = minimumDuration({
+    reading: [{ text: "short one" }, { text: "a considerably longer line of copy here" }],
+  });
+  assert.ok(min > 2.5, `expected room for two lines, got ${min}`);
+});
+
+test("the solver refuses a target shorter than the copy's reading floor", () => {
+  const graph = {
+    scenes: [
+      { id: "a", duration: 4, reading: [{ text: "a line of about seven words here" }] },
+      { id: "b", duration: 4, reading: [{ text: "another line of about seven words here" }] },
+    ],
+    seams: [],
+  };
+  const plan = solveTiming(graph, { targetDuration: 2 });
+  assert.equal(plan.ok, false);
+  assert.equal(plan.violations[0].kind, "target_too_short");
+  assert.match(plan.violations[0].message, /the floor does not move/);
+});
+
+test("the solver tightens dwell rather than reading time when it can", () => {
+  /* Both scenes carry enough copy that their preferred length survives the
+     trim, so the only way to reach the target is the dwell above each floor. */
+  const graph = {
+    scenes: [
+      { id: "a", duration: 6, reading: [{ text: "a line of roughly twelve words that takes real time to read" }] },
+      { id: "b", duration: 6, reading: [{ text: "another line of roughly twelve words that also takes time to read" }] },
+    ],
+    seams: [],
+  };
+  const target = 9;
+  const plan = solveTiming(graph, { targetDuration: target });
+  assert.equal(plan.ok, true);
+  assert.ok(plan.total <= target + 0.01, `expected to fit ${target}s, got ${plan.total}`);
+  for (const s of plan.scenes) {
+    assert.ok(s.duration >= s.min, `${s.id} fell below its floor: ${s.duration} < ${s.min}`);
+  }
+  assert.ok(
+    plan.relaxations.some((r) => r.kind === "comprehension_dwell"),
+    `expected a dwell squeeze, got ${plan.relaxations.map((r) => r.kind).join(", ")}`,
+  );
+});
+
+test("a cut only moves to a musical cue when the scene can afford it", () => {
+  const graph = {
+    scenes: [
+      { id: "a", duration: 4, reading: [{ text: "one two three" }] },
+      { id: "b", duration: 4, reading: [{ text: "four five six" }] },
+    ],
+    seams: [],
+  };
+  const cut = solveTiming(graph).scenes[1].start;
+  const generous = solveTiming(graph, { strongCues: [cut + 0.1] });
+  assert.equal(generous.cut_locks.length, 1);
+  assert.equal(generous.cut_locks[0].at, Number((cut + 0.1).toFixed(2)));
+
+  /* A cue that would starve the previous scene is left alone, and said so.
+     Since a cue may only pull a cut by 0.15s, starvation is only possible for
+     a scene already sitting within that of its own floor — which is exactly
+     the case worth protecting. */
+  const floor = minimumDuration({ reading: [{ text: "one two three" }] });
+  const tightGraph = {
+    scenes: [
+      { id: "a", duration: floor + 0.06, reading: [{ text: "one two three" }] },
+      { id: "b", duration: 4, reading: [{ text: "four five six" }] },
+    ],
+    seams: [],
+  };
+  const starved = solveTiming(tightGraph, { strongCues: [floor - 0.06] });
+  assert.equal(starved.cut_locks.length, 0, "a cue must not push a scene below its reading floor");
+  assert.equal(starved.relaxations.at(-1).kind, "cue_dropped");
+  assert.match(starved.relaxations.at(-1).message, /reading floor/);
+});
+
+test("copy that cannot be read in its scene is reported with the numbers", () => {
+  const graph = {
+    format: { width: 1920, height: 1080, fps: 30 },
+    scenes: [
+      { id: "hook", duration: 3, reading: [{ text: "fine" }] },
+      { id: "rushed", duration: 0.3, reading: [{ text: "six whole words go by here" }] },
+    ],
+    seams: [],
+  };
+  const findings = detectUnreadableCopy(tightScenes(graph));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].scene, "rushed");
+  assert.equal(findings[0].code, "reading_floor_violated");
+  assert.match(findings[0].message, /needs 1\.8s/);
+});
+
+/* ------------------------------------------------------------------ pixels */
+
+test("a flat frame is recognised as flat, and a real one is not", () => {
+  const black = { w: 8, h: 8, data: new Uint8Array(64).fill(2) };
+  assert.equal(isFlat(black).flat, true);
+  assert.equal(isFlat(black).dark, true);
+
+  const real = grayWithInkAt(0.4);
+  assert.equal(isFlat(real).flat, false);
+});
+
+test("row ink finds the band the text is actually on", () => {
+  const rows = rowInk(grayWithInkAt(0.5));
+  const brightest = rows.indexOf(Math.max(...rows));
+  assert.ok(Math.abs(brightest / rows.length - 0.5) < 0.08, `ink found at ${brightest / rows.length}`);
+});
+
+test("two different layouts hash differently; the same one does not", () => {
+  const a = aHash(grayWithInkAt(0.2));
+  const b = aHash(grayWithInkAt(0.8));
+  const c = aHash(grayWithInkAt(0.2));
+  assert.equal(hamming(a, c), 0);
+  assert.ok(hamming(a, b) > 4, `expected distinct layouts, distance was ${hamming(a, b)}`);
+});
+
+/* ------------------------------------------------------------------ detectors */
+
+test("a black frame is a finding where content is due, and frame zero says why it matters", () => {
+  const black = { flat: true, dark: true, mean: 1, stdDev: 0.4 };
+  const findings = detectFlatFrames([
+    frame({ kind: "frame_zero", at: 0, tone: black }),
+    frame({ kind: "midpoint", at: 12, scene: "proof", tone: black }),
+    /* Mid-transition is black by construction — the outgoing scene has left
+       and the incoming one has not arrived. Flagging it reports the technique
+       as the defect. */
+    frame({ kind: "at_cut", at: 4.5, scene: "mechanism", tone: black }),
+    frame({ kind: "post_cut", at: 4.75, scene: "mechanism", tone: black }),
+  ]);
+  assert.equal(findings.length, 2, "only composed moments count");
+  assert.equal(findings[0].code, "black_frame");
+  assert.match(findings[0].message, /thumbnail/);
+  assert.equal(findings[1].scene, "proof");
+});
+
+test("the final frame is allowed to rest on a clean ground", () => {
+  const findings = detectFlatFrames([
+    frame({ kind: "final", tone: { flat: true, dark: true, mean: 1, stdDev: 0.2 } }),
+  ]);
+  assert.equal(findings.length, 0);
+});
+
+test("content in the caption band is caught, above it is not", () => {
+  const low = rowInk(grayWithInkAt(0.92)).map((v) => Number(v.toFixed(3)));
+  const high = rowInk(grayWithInkAt(0.45)).map((v) => Number(v.toFixed(3)));
+
+  const caught = detectCaptionZone([frame({ ink: low, scene: "outro", at: 12 })]);
+  assert.equal(caught.length, 1);
+  assert.equal(caught[0].code, "caption_zone_collision");
+  assert.equal(caught[0].scene, "outro");
+
+  assert.equal(detectCaptionZone([frame({ ink: high })]).length, 0);
+});
+
+test("two scenes with the same layout are reported once, naming both", () => {
+  const inkAt = (f) => rowInk(grayWithInkAt(f)).map((v) => Number(v.toFixed(3)));
+  const same = inkAt(0.4);
+  const findings = detectRepeatedLayouts([
+    frame({ scene: "a", kind: "midpoint", ink: same }),
+    frame({ scene: "b", kind: "midpoint", ink: same }),
+    /* Frames from within one scene must not count as a repeat. */
+    frame({ scene: "a", kind: "settled_read", ink: same }),
+  ]);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].code, "repeated_layout");
+  assert.match(findings[0].message, /"a" and "b"/);
+});
+
+test("scenes that place content differently are not called repetitive", () => {
+  const inkAt = (f) => rowInk(grayWithInkAt(f)).map((v) => Number(v.toFixed(3)));
+  const findings = detectRepeatedLayouts([
+    frame({ scene: "a", kind: "midpoint", ink: inkAt(0.25) }),
+    frame({ scene: "b", kind: "midpoint", ink: inkAt(0.6) }),
+  ]);
+  assert.equal(findings.length, 0);
+});
+
+test("the layout signature reads bands of content, not overall brightness", () => {
+  const sig = (f) =>
+    layoutSignature(frame({ ink: rowInk(grayWithInkAt(f)).map((v) => Number(v.toFixed(3))) }));
+  assert.equal(hamming(sig(0.3), sig(0.3)), 0);
+  assert.ok(hamming(sig(0.2), sig(0.85)) >= 2, "bands far apart must differ");
+});
+
+/* ------------------------------------------------------------------ sampling */
+
+test("frame sampling covers the thumbnail, every cut, and the last frame", () => {
+  const graph = {
+    scenes: [
+      { id: "a", duration: 4, reading: [{ text: "one" }] },
+      { id: "b", duration: 4, reading: [{ text: "two" }] },
+    ],
+    seams: [{ from: "a", to: "b", at: 4, vector: { axis: "x", direction: "left" } }],
+  };
+  const kinds = new Set(chooseTimes(graph, { duration: 8 }).map((t) => t.kind));
+  for (const required of ["frame_zero", "midpoint", "settled_read", "pre_cut", "at_cut", "post_cut", "final"]) {
+    assert.ok(kinds.has(required), `sampling missed ${required}`);
+  }
+});
+
+/* ------------------------------------------------------------------ sameness */
+
+test("every visual world is a genuinely different look", () => {
+  const worlds = loadWorlds();
+  assert.ok(worlds.length >= 3, "a catalogue needs enough worlds to choose between");
+  assertDistinct(worlds);
+  const signatures = new Set(worlds.map(worldSignature));
+  assert.equal(signatures.size, worlds.length, "two worlds share a camera/depth/transition triple");
+});
+
+test("two worlds with the same triple are rejected", () => {
+  const twin = (id) => ({
+    id,
+    camera_model: "locked",
+    depth_levels: 1,
+    transition_families: ["cut", "mask"],
+  });
+  assert.throws(() => assertDistinct([twin("a"), twin("b")]), /same look under different names/);
+});
+
+test("scenes rotate through layouts instead of repeating one", () => {
+  const world = loadWorlds().find((w) => w.layouts.length >= 3);
+  const scenes = [
+    { id: "a", role: "Hook" },
+    { id: "b", role: "Product_Intro" },
+    { id: "c", role: "Key_Feature" },
+    { id: "d", role: "Brand_Outro" },
+  ];
+  const assigned = assignLayouts(world, scenes);
+  for (let i = 1; i < assigned.length; i++) {
+    assert.notEqual(
+      assigned[i].layout.id,
+      assigned[i - 1].layout.id,
+      "consecutive scenes must not be composed identically",
+    );
+  }
+});
+
+test("cut-the-curve is a slide, not a zoom", () => {
+  assert.equal(familyOf("cut-the-curve LEFT"), "slide");
+  assert.equal(familyOf("zoom-through"), "zoom");
+  assert.equal(familyOf("inverse zoom-through"), "zoom");
+  assert.equal(familyOf(undefined), "cut");
+});
+
+test("a film that spends one move on every cut is refused", () => {
+  const world = loadWorlds()[0];
+  const graph = {
+    objects: [],
+    scenes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+    seams: [
+      { from: "a", to: "b", technique: "cut-the-curve LEFT" },
+      { from: "b", to: "c", technique: "cut-the-curve LEFT" },
+    ],
+  };
+  const result = checkSameness(fingerprint({ graph, world }), []);
+  assert.equal(result.ok, false);
+  assert.equal(result.violations[0].code, "one_note_transitions");
+});
+
+test("varying the cuts satisfies the gate", () => {
+  const world = loadWorlds()[0];
+  const graph = {
+    objects: [],
+    scenes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+    seams: [
+      { from: "a", to: "b", technique: "cut-the-curve LEFT" },
+      { from: "b", to: "c", technique: "zoom-through" },
+    ],
+  };
+  assert.equal(checkSameness(fingerprint({ graph, world }), []).ok, true);
+});
+
+test("the same construction twice is caught by similarity", () => {
+  const world = loadWorlds()[0];
+  const graph = {
+    objects: [{ id: "o", kind: "text", importance: 3 }],
+    scenes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+    seams: [
+      { from: "a", to: "b", technique: "cut-the-curve LEFT" },
+      { from: "b", to: "c", technique: "zoom-through" },
+    ],
+  };
+  const fp = fingerprint({ graph, world });
+  assert.equal(similarity(fp, fp), 1);
+
+  const repeat = checkSameness(fp, [fp]);
+  assert.equal(repeat.ok, false);
+  assert.equal(repeat.violations[0].code, "too_similar");
+
+  /* A different world changes camera, depth, typography and layouts at once,
+     which is what makes it a different video rather than a reskin. */
+  const other = loadWorlds().find((w) => w.id !== world.id);
+  const fresh = checkSameness(fingerprint({ graph, world: other }), [fp]);
+  assert.ok(
+    !fresh.violations.some((v) => v.code === "too_similar"),
+    `a different world should not read as a repeat (nearest ${fresh.nearest?.score})`,
+  );
+});

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -200,7 +200,7 @@ test("content in the caption band is caught, above it is not", () => {
   assert.equal(detectCaptionZone([frame({ ink: high })]).length, 0);
 });
 
-test("two scenes with the same layout are reported once, naming both", () => {
+test("a cut that lands back on the same composition is reported, naming both", () => {
   const inkAt = (f) => rowInk(grayWithInkAt(f)).map((v) => Number(v.toFixed(3)));
   const same = inkAt(0.4);
   const findings = detectRepeatedLayouts([
@@ -211,7 +211,40 @@ test("two scenes with the same layout are reported once, naming both", () => {
   ]);
   assert.equal(findings.length, 1);
   assert.equal(findings[0].code, "repeated_layout");
-  assert.match(findings[0].message, /"a" and "b"/);
+  assert.match(findings[0].message, /"a" cuts to "b"/);
+});
+
+test("a composition reused inside its budget, never twice in a row, is allowed", () => {
+  const inkAt = (f) => rowInk(grayWithInkAt(f)).map((v) => Number(v.toFixed(3)));
+  const a = inkAt(0.25);
+  const b = inkAt(0.6);
+  /* A world ships four layouts, so demanding a distinct picture for every
+     scene is unsatisfiable — and the assigner already budgets reuse at 40%. */
+  const findings = detectRepeatedLayouts([
+    frame({ scene: "one", kind: "midpoint", ink: a }),
+    frame({ scene: "two", kind: "midpoint", ink: b }),
+    frame({ scene: "three", kind: "midpoint", ink: a }),
+    frame({ scene: "four", kind: "midpoint", ink: b }),
+  ]);
+  assert.deepEqual(findings, []);
+});
+
+test("one composition carrying more of the film than the budget is reported", () => {
+  const inkAt = (f) => rowInk(grayWithInkAt(f)).map((v) => Number(v.toFixed(3)));
+  const a = inkAt(0.25);
+  const b = inkAt(0.6);
+  /* Three of five on one picture against a budget of two, and never adjacent,
+     so the only thing wrong is how much of the film it carries. */
+  const findings = detectRepeatedLayouts([
+    frame({ scene: "one", kind: "midpoint", ink: a }),
+    frame({ scene: "two", kind: "midpoint", ink: b }),
+    frame({ scene: "three", kind: "midpoint", ink: a }),
+    frame({ scene: "four", kind: "midpoint", ink: b }),
+    frame({ scene: "five", kind: "midpoint", ink: a }),
+  ]);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].code, "repeated_layout");
+  assert.match(findings[0].message, /3 of 5 scenes/);
 });
 
 test("scenes that place content differently are not called repetitive", () => {
@@ -344,4 +377,49 @@ test("the same construction twice is caught by similarity", () => {
     !fresh.violations.some((v) => v.code === "too_similar"),
     `a different world should not read as a repeat (nearest ${fresh.nearest?.score})`,
   );
+});
+
+/* -------------------------------------------------- the ink noise floor */
+
+test("a background a few levels off does not register as ink", () => {
+  /* A page whose bottom band renders slightly brighter than the rest — an
+     encoder seam, a panel a shade off — with real text higher up. Rows are
+     normalised against the frame's own peak, so on a sparse frame that
+     invisible shift used to normalise up into something the caption detector
+     reported as copy in an empty band. */
+  const w = 64;
+  const h = 36;
+  const data = new Uint8Array(w * h).fill(244);
+  for (let x = 4; x < w - 4; x++) {
+    data[14 * w + x] = 40;
+    data[15 * w + x] = 40;
+  }
+  for (let y = 34; y < h; y++) for (let x = 0; x < w; x++) data[y * w + x] = 249;
+
+  const ink = rowInk({ w, h, data });
+  assert.ok(ink[14] > 0.9, "the text row is the peak");
+  assert.equal(ink[34], 0, "a five-level background shift is not ink");
+  assert.equal(ink[35], 0);
+  assert.equal(detectCaptionZone([frame({ ink, scene: "outro", at: 3 })]).length, 0);
+});
+
+/* ----------------------------------------------------- layout assignment */
+
+test("layouts are spread across anchors, not only across ids", () => {
+  const world = {
+    id: "w",
+    layouts: [
+      { id: "one", align: "center", anchor: "middle" },
+      { id: "two", align: "leading", anchor: "middle" },
+      { id: "three", align: "center", anchor: "upper" },
+      { id: "four", align: "leading", anchor: "lower" },
+    ],
+  };
+  const scenes = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+  const anchors = assignLayouts(world, scenes).map((a) => a.layout.anchor);
+
+  /* Two layouts sharing an anchor put content in the same band, which is what
+     a viewer reads as the same picture — rotating ids alone would give
+     middle, middle, upper, lower and look repetitive while every id differed. */
+  assert.equal(new Set(anchors).size, 3, `anchors used: ${anchors.join(", ")}`);
 });

--- a/worlds/code-as-architecture.json
+++ b/worlds/code-as-architecture.json
@@ -1,0 +1,81 @@
+{
+  "schema": "brag.visual_world/1",
+  "id": "code-as-architecture",
+  "name": "Code as architecture",
+  "summary": "Source treated as structure: files as volumes, calls as spans between them. The camera moves through the codebase rather than scrolling a file.",
+  "camera_model": "push",
+  "depth_levels": 5,
+  "transition_families": [
+    "zoom",
+    "morph",
+    "slide"
+  ],
+  "motion_intensity": "moderate",
+  "background": {
+    "kind": "flat",
+    "detail": "deep ground so the structure reads as built rather than drawn"
+  },
+  "typography": {
+    "display_scale": 0.9,
+    "case": "sentence",
+    "lead_family": "mono",
+    "measure": 1200
+  },
+  "layouts": [
+    {
+      "id": "elevation",
+      "align": "center",
+      "anchor": "middle",
+      "scale": 1,
+      "inset": 0.08,
+      "chrome": "none",
+      "best_for": [
+        "Product_Intro",
+        "Key_Feature"
+      ]
+    },
+    {
+      "id": "section-cut",
+      "align": "leading",
+      "anchor": "split",
+      "scale": 0.85,
+      "inset": 0.06,
+      "chrome": "rule",
+      "best_for": [
+        "Problem",
+        "Benefits"
+      ]
+    },
+    {
+      "id": "close-detail",
+      "align": "leading",
+      "anchor": "lower",
+      "scale": 0.75,
+      "inset": 0.07,
+      "chrome": "panel",
+      "best_for": [
+        "Social_Proof"
+      ]
+    },
+    {
+      "id": "wide-establish",
+      "align": "center",
+      "anchor": "upper",
+      "scale": 1.3,
+      "inset": 0.14,
+      "chrome": "none",
+      "best_for": [
+        "Hook",
+        "Brand_Outro"
+      ]
+    }
+  ],
+  "avoid": [
+    "syntax-highlighted screenshots as wallpaper"
+  ],
+  "suits_surfaces": [
+    "library",
+    "cli",
+    "api"
+  ]
+}

--- a/worlds/evidence-board.json
+++ b/worlds/evidence-board.json
@@ -1,0 +1,82 @@
+{
+  "schema": "brag.visual_world/1",
+  "id": "evidence-board",
+  "name": "Documentary evidence board",
+  "summary": "Findings pinned up and connected. Each claim arrives as a piece of evidence with its source attached, and the connections between them are drawn.",
+  "camera_model": "orbit",
+  "depth_levels": 3,
+  "transition_families": [
+    "zoom",
+    "rotate",
+    "cut"
+  ],
+  "motion_intensity": "moderate",
+  "background": {
+    "kind": "panel",
+    "detail": "a board the pieces are attached to, lit from one side"
+  },
+  "typography": {
+    "display_scale": 0.95,
+    "case": "sentence",
+    "lead_family": "sans",
+    "measure": 900
+  },
+  "layouts": [
+    {
+      "id": "pinned-centre",
+      "align": "center",
+      "anchor": "middle",
+      "scale": 1,
+      "inset": 0.1,
+      "chrome": "panel",
+      "best_for": [
+        "Social_Proof",
+        "Key_Feature"
+      ]
+    },
+    {
+      "id": "cluster",
+      "align": "leading",
+      "anchor": "upper",
+      "scale": 0.8,
+      "inset": 0.08,
+      "chrome": "panel",
+      "best_for": [
+        "Problem",
+        "Benefits"
+      ]
+    },
+    {
+      "id": "single-exhibit",
+      "align": "center",
+      "anchor": "upper",
+      "scale": 1.2,
+      "inset": 0.15,
+      "chrome": "frame",
+      "best_for": [
+        "Hook"
+      ]
+    },
+    {
+      "id": "conclusion",
+      "align": "center",
+      "anchor": "middle",
+      "scale": 1.35,
+      "inset": 0.16,
+      "chrome": "none",
+      "best_for": [
+        "Brand_Outro",
+        "CTA"
+      ]
+    }
+  ],
+  "avoid": [
+    "stock imagery",
+    "anything that looks like a slide deck"
+  ],
+  "suits_surfaces": [
+    "research",
+    "api",
+    "website"
+  ]
+}

--- a/worlds/kinetic-editorial.json
+++ b/worlds/kinetic-editorial.json
@@ -1,0 +1,81 @@
+{
+  "schema": "brag.visual_world/1",
+  "id": "kinetic-editorial",
+  "name": "Kinetic editorial",
+  "summary": "Magazine typography that moves. Rules, columns and a strict baseline; the motion is the words changing rather than the boxes sliding.",
+  "camera_model": "locked",
+  "depth_levels": 1,
+  "transition_families": [
+    "cut",
+    "mask"
+  ],
+  "motion_intensity": "energetic",
+  "background": {
+    "kind": "rule",
+    "detail": "hairline rules that divide the page and survive the cut"
+  },
+  "typography": {
+    "display_scale": 1.35,
+    "case": "sentence",
+    "lead_family": "sans",
+    "measure": 1500
+  },
+  "layouts": [
+    {
+      "id": "broadsheet",
+      "align": "leading",
+      "anchor": "top",
+      "scale": 1.3,
+      "inset": 0.08,
+      "chrome": "rule",
+      "best_for": [
+        "Hook",
+        "Problem"
+      ]
+    },
+    {
+      "id": "column",
+      "align": "leading",
+      "anchor": "middle",
+      "scale": 0.9,
+      "inset": 0.12,
+      "chrome": "none",
+      "best_for": [
+        "Key_Feature",
+        "Benefits"
+      ]
+    },
+    {
+      "id": "standfirst",
+      "align": "center",
+      "anchor": "middle",
+      "scale": 1.5,
+      "inset": 0.14,
+      "chrome": "none",
+      "best_for": [
+        "Brand_Outro",
+        "CTA"
+      ]
+    },
+    {
+      "id": "caption-row",
+      "align": "leading",
+      "anchor": "lower",
+      "scale": 0.7,
+      "inset": 0.08,
+      "chrome": "rule",
+      "best_for": [
+        "Social_Proof"
+      ]
+    }
+  ],
+  "avoid": [
+    "centred everything",
+    "drop shadows"
+  ],
+  "suits_surfaces": [
+    "website",
+    "research",
+    "library"
+  ]
+}

--- a/worlds/minimal-cinematic-type.json
+++ b/worlds/minimal-cinematic-type.json
@@ -1,0 +1,84 @@
+{
+  "schema": "brag.visual_world/1",
+  "id": "minimal-cinematic-type",
+  "name": "Minimal cinematic typography",
+  "summary": "One idea at a time, very large, on empty ground. Restraint is the effect; the cut does the work the motion would otherwise do.",
+  "camera_model": "scroll",
+  "depth_levels": 2,
+  "transition_families": [
+    "dissolve",
+    "slide",
+    "cut"
+  ],
+  "motion_intensity": "restrained",
+  "background": {
+    "kind": "gradient",
+    "detail": "a ground that shifts almost imperceptibly across the film"
+  },
+  "typography": {
+    "display_scale": 1.6,
+    "case": "sentence",
+    "lead_family": "sans",
+    "measure": 1400
+  },
+  "layouts": [
+    {
+      "id": "single-line",
+      "align": "center",
+      "anchor": "middle",
+      "scale": 1.6,
+      "inset": 0.14,
+      "chrome": "none",
+      "best_for": [
+        "Hook",
+        "Brand_Outro"
+      ]
+    },
+    {
+      "id": "low-left",
+      "align": "leading",
+      "anchor": "lower",
+      "scale": 1.1,
+      "inset": 0.1,
+      "chrome": "none",
+      "best_for": [
+        "Problem",
+        "Benefits"
+      ]
+    },
+    {
+      "id": "high-right",
+      "align": "trailing",
+      "anchor": "upper",
+      "scale": 1.1,
+      "inset": 0.1,
+      "chrome": "none",
+      "best_for": [
+        "Key_Feature",
+        "Social_Proof"
+      ]
+    },
+    {
+      "id": "stacked",
+      "align": "leading",
+      "anchor": "middle",
+      "scale": 0.95,
+      "inset": 0.12,
+      "chrome": "none",
+      "best_for": [
+        "Product_Intro",
+        "CTA"
+      ]
+    }
+  ],
+  "avoid": [
+    "more than one idea per frame",
+    "any panel or card"
+  ],
+  "suits_surfaces": [
+    "website",
+    "mobile",
+    "desktop",
+    "game"
+  ]
+}

--- a/worlds/spatial-terminal.json
+++ b/worlds/spatial-terminal.json
@@ -1,0 +1,23 @@
+{
+  "schema": "brag.visual_world/1",
+  "id": "spatial-terminal",
+  "name": "Spatial terminal",
+  "summary": "Terminal surfaces held in a dark workspace at different depths, with the camera travelling between them. The command line is treated as the product's interface rather than as evidence pasted into a slide.",
+  "camera_model": "perspective-flight",
+  "depth_levels": 4,
+  "transition_families": ["zoom", "slide", "morph"],
+  "motion_intensity": "restrained",
+  "background": { "kind": "vignette", "detail": "an unlit workspace that the surfaces sit inside, not a backdrop behind them" },
+  "typography": { "display_scale": 0.85, "case": "sentence", "lead_family": "mono", "measure": 1300 },
+  "layouts": [
+    { "id": "surface-near", "align": "leading", "anchor": "middle", "scale": 1.0, "inset": 0.06, "chrome": "panel", "best_for": ["Product_Intro", "Key_Feature"] },
+    { "id": "surface-pair", "align": "leading", "anchor": "split", "scale": 0.82, "inset": 0.05, "chrome": "panel", "best_for": ["Problem", "Social_Proof"] },
+    { "id": "statement", "align": "leading", "anchor": "upper", "scale": 1.25, "inset": 0.1, "chrome": "none", "best_for": ["Hook", "Brand_Outro"] },
+    { "id": "surface-far", "align": "center", "anchor": "middle", "scale": 0.68, "inset": 0.12, "chrome": "frame", "best_for": ["Benefits", "CTA"] }
+  ],
+  "avoid": [
+    "screenshots floating on a coloured card",
+    "a terminal used as decoration behind headline type"
+  ],
+  "suits_surfaces": ["cli", "library", "api"]
+}

--- a/worlds/technical-blueprint.json
+++ b/worlds/technical-blueprint.json
@@ -1,0 +1,83 @@
+{
+  "schema": "brag.visual_world/1",
+  "id": "technical-blueprint",
+  "name": "Technical blueprint",
+  "summary": "Measured drawing. Content is annotated, dimensioned and connected by leader lines, as though the product were being specified rather than advertised.",
+  "camera_model": "planar-drift",
+  "depth_levels": 2,
+  "transition_families": [
+    "slide",
+    "dissolve",
+    "mask"
+  ],
+  "motion_intensity": "restrained",
+  "background": {
+    "kind": "grid",
+    "detail": "a faint measured grid that the camera drifts across"
+  },
+  "typography": {
+    "display_scale": 0.8,
+    "case": "upper",
+    "lead_family": "mono",
+    "measure": 1100
+  },
+  "layouts": [
+    {
+      "id": "plan-view",
+      "align": "center",
+      "anchor": "middle",
+      "scale": 0.9,
+      "inset": 0.1,
+      "chrome": "frame",
+      "best_for": [
+        "Product_Intro",
+        "Key_Feature"
+      ]
+    },
+    {
+      "id": "annotated-left",
+      "align": "leading",
+      "anchor": "upper",
+      "scale": 0.85,
+      "inset": 0.07,
+      "chrome": "rule",
+      "best_for": [
+        "Problem",
+        "Benefits"
+      ]
+    },
+    {
+      "id": "detail-callout",
+      "align": "trailing",
+      "anchor": "lower",
+      "scale": 0.7,
+      "inset": 0.07,
+      "chrome": "panel",
+      "best_for": [
+        "Social_Proof"
+      ]
+    },
+    {
+      "id": "title-block",
+      "align": "leading",
+      "anchor": "lower",
+      "scale": 1,
+      "inset": 0.06,
+      "chrome": "frame",
+      "best_for": [
+        "Hook",
+        "Brand_Outro"
+      ]
+    }
+  ],
+  "avoid": [
+    "gradients",
+    "soft focus"
+  ],
+  "suits_surfaces": [
+    "api",
+    "hardware",
+    "library",
+    "research"
+  ]
+}


### PR DESCRIPTION
## What this is

`/brag` decides what to *say* very well. It has almost no way of knowing whether the video actually said it. This adds the missing half: a CLI the skill drives, where every stage ends at an artifact that either validates or fails, and four verification layers that read the rendered result rather than the plan that produced it.

**It is still one command.** The user runs `/brag`; the agent walks the stages and answers the specs. `brag status` derives progress from artifacts on disk, so a run that dies halfway resumes truthfully instead of starting over.

## Why

Three things kept going wrong in practice, and none of them were visible to `hyperframes check`:

- **Every product was assumed to be a website.** All five bundled examples are marketing sites. A command-line tool has no hero headline, and treating its terminal as supporting material instead of the product interface is the difference between a usable video and a typographic one.
- **The only gate was blind to content.** A `white-space: pre` bug once made half a terminal invisible and `check` still passed. A poster showed a scene's second line with the first still missing — also green.
- **Re-runs had no structure.** "Use a timestamped directory" was the whole story.

## What it adds

**Surface-aware inspection.** Classify first — website, cli, library, api, desktop, mobile, game, hardware, research, mixed — then read on the surface's own terms. A deterministic scan supplies file signals, extracted strings with byte offsets, real git history and the real palette; the model supplies only what a scan cannot decide.

**Product truth, checked.** A verbatim string must be byte-for-byte present in the file it cites. A claim must resolve to a proof id. A rendered line must resolve to a source or the review fails.

**Real capture.** Run the real command and keep the byte stream, replayed through a terminal emulator so carriage returns and line erasure survive — spinners and progress bars are exactly the moments worth showing, and a regex turns them into garbage. Nothing runs until the user approves the plan; secrets are redacted before anything reaches disk.

**Timing solved, not asserted.** Per scene: entry, each line's reading floor, dwell, exit, ceiling. When they disagree it relaxes in a fixed order and never touches a reading floor. If it still doesn't fit, it refuses — silently truncating a line is how a video ends up with copy nobody can read.

**Repetition measured.** Concepts must be genuinely different before one is locked, and the locked concept becomes a constraint its own implementation is checked against. Visual worlds decide how a product physically exists on screen; two declaring the same camera × depth × transition vocabulary are rejected, because fifteen names for three looks is how a catalogue like this rots.

**Compiles into what HyperFrames already reads.** `BRIEF.md`, `STORYBOARD.md`, `frame.md`, `ledger.json`, a `*.motion.json` sidecar. Nothing competes with it. Seams are described as vectors and stamped by motion-doctrine, passing its gate by construction. Because the scene graph sits upstream of any one project, a format variant is a recompile rather than a re-cut.

## Two things I'd flag for review

**The narrative layer reports; it does not gate.** It's a stochastic grader, so it's measured against five labelled fixtures that print a confusion matrix on every test run, and a test asserts it stays non-gating until that matrix justifies otherwise. Current: `tp 3 fp 0 tn 2 fn 0` at threshold 0.7.

**The whole design rests on compiling being deterministic** — same graph in, identical bytes out. That's what lets a scoped revision prove it only touched the scenes it named. Worth checking that assumption holds on your machines too. One wrinkle already handled: opening a project with `hyperframes check` rewrites `index.html` to inject Studio's identity attributes, so the comparison strips those and compares everything authored exactly.

## Notes

- **Zero runtime dependencies in the core.** The CLI ships inside the plugin and runs as `node "$CLAUDE_PLUGIN_ROOT/cli/brag.mjs"`. JSON Schema validation is hand-rolled for the subset used, because requiring `npm install` in a version-pinned plugin directory is a reliability problem rather than a convenience. A terminal emulator is needed only for capture.
- **65 tests**, `node --test`, no framework.
- Existing tone presets, SFX library, music and cue tooling are untouched and still drive the writing.
- The six visual worlds are deliberately few. The catalogue should grow as each new one is shown to render differently from the others, not before.

Happy to split this into smaller PRs if that's easier to review — the natural seams are inspection + product truth, the timing solver, the visual worlds, and the verification layers.
