### PR TITLE
Add pause control to the hero video

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,18 +43,25 @@
         playsinline
         preload="auto"
       ></video>
-      <button id="hero-mute" class="hero-mute" type="button" aria-label="unmute brag video" aria-pressed="true">
-        <svg class="icon-play" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M8 5v14l11-7z"/>
-        </svg>
-        <svg class="icon-muted" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M3 9v6h4l5 4V5L7 9H3zm13.59 3l2.7-2.7-1.41-1.42L15.17 10.6 12.46 7.88l-1.41 1.41 2.71 2.71-2.71 2.71 1.41 1.41 2.71-2.7 2.71 2.7 1.41-1.41-2.7-2.7z"/>
-        </svg>
-        <svg class="icon-sound" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M3 9v6h4l5 4V5L7 9H3zm10.5 3a4.5 4.5 0 00-2.5-4.03v8.05A4.5 4.5 0 0013.5 12zm-2.5-9v2.06A7 7 0 0117 12a7 7 0 01-6 6.92V21A9 9 0 0019 12 9 9 0 0011 3z"/>
-        </svg>
-        <span class="hero-mute-label">tap for sound</span>
-      </button>
+      <div class="hero-controls">
+        <button id="hero-playback" class="hero-control hero-playback" type="button" aria-label="play brag video" title="play brag video" data-mode="play">
+          <svg class="icon-play" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M8 5v14l11-7z"/>
+          </svg>
+          <svg class="icon-pause" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M6 5h4v14H6zm8 0h4v14h-4z"/>
+          </svg>
+        </button>
+        <button id="hero-mute" class="hero-control hero-mute" type="button" aria-label="unmute brag video" aria-pressed="true">
+          <svg class="icon-muted" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M3 9v6h4l5 4V5L7 9H3zm13.59 3l2.7-2.7-1.41-1.42L15.17 10.6 12.46 7.88l-1.41 1.41 2.71 2.71-2.71 2.71 1.41 1.41 2.71-2.7 2.71 2.7 1.41-1.41-2.7-2.7z"/>
+          </svg>
+          <svg class="icon-sound" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M3 9v6h4l5 4V5L7 9H3zm10.5 3a4.5 4.5 0 00-2.5-4.03v8.05A4.5 4.5 0 0013.5 12zm-2.5-9v2.06A7 7 0 0117 12a7 7 0 01-6 6.92V21A9 9 0 0019 12 9 9 0 0011 3z"/>
+          </svg>
+          <span class="hero-mute-label">tap for sound</span>
+        </button>
+      </div>
     </aside>
   </div>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,21 +1,21 @@
 (() => {
   // Hero playback and mute controls
   const heroVid = document.getElementById('hero-vid');
+  const heroPlayback = document.getElementById('hero-playback');
   const heroMute = document.getElementById('hero-mute');
-  if (heroVid && heroMute) {
+  if (heroVid && heroPlayback && heroMute) {
     const heroMuteLabel = heroMute.querySelector('.hero-mute-label');
     const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
-    const setControlMode = (mode) => {
-      if (mode === 'play') {
-        heroMute.dataset.mode = 'play';
-        heroMute.removeAttribute('aria-pressed');
-        heroMute.setAttribute('aria-label', 'play brag video');
-        if (heroMuteLabel) heroMuteLabel.textContent = 'play video';
-        return;
-      }
+    const syncPlaybackControl = () => {
+      const mode = heroVid.paused ? 'play' : 'pause';
+      const label = `${mode} brag video`;
+      heroPlayback.dataset.mode = mode;
+      heroPlayback.setAttribute('aria-label', label);
+      heroPlayback.setAttribute('title', label);
+    };
 
-      delete heroMute.dataset.mode;
+    const syncMuteControl = () => {
       heroMute.setAttribute('aria-pressed', heroVid.muted ? 'true' : 'false');
       heroMute.setAttribute('aria-label', heroVid.muted ? 'unmute brag video' : 'mute brag video');
       if (heroMuteLabel) heroMuteLabel.textContent = 'tap for sound';
@@ -25,36 +25,33 @@
       if (reducedMotion.matches) {
         heroVid.pause();
         heroVid.load();
-        setControlMode('play');
+        syncPlaybackControl();
         return;
       }
 
       heroVid.muted = true;
-      setControlMode('mute');
+      syncMuteControl();
       const playback = heroVid.play();
-      if (playback && playback.catch) playback.catch(() => {});
+      if (playback && playback.catch) playback.catch(syncPlaybackControl);
     };
 
-    heroMute.addEventListener('click', () => {
-      if (heroMute.dataset.mode === 'play') {
-        heroVid.muted = false;
-        setControlMode('mute');
+    heroPlayback.addEventListener('click', () => {
+      if (heroVid.paused) {
         const playback = heroVid.play();
-        if (playback && playback.catch) playback.catch(() => {});
+        if (playback && playback.catch) playback.catch(syncPlaybackControl);
         return;
       }
 
-      const wasMuted = heroVid.muted;
-      heroVid.muted = !wasMuted;
-      heroMute.setAttribute('aria-pressed', wasMuted ? 'false' : 'true');
-      heroMute.setAttribute('aria-label', wasMuted ? 'mute brag video' : 'unmute brag video');
-      // When unmuting, ensure it actually plays with sound (some browsers require gesture)
-      if (!heroVid.muted) {
-        const p = heroVid.play();
-        if (p && p.catch) p.catch(() => {});
-      }
+      heroVid.pause();
     });
 
+    heroMute.addEventListener('click', () => {
+      heroVid.muted = !heroVid.muted;
+      syncMuteControl();
+    });
+
+    heroVid.addEventListener('play', syncPlaybackControl);
+    heroVid.addEventListener('pause', syncPlaybackControl);
     applyMotionPreference();
     reducedMotion.addEventListener('change', applyMotionPreference);
   }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -251,21 +251,23 @@ button { font: inherit; cursor: pointer; }
   display: block;
 }
 
-/* Mute toggle, lower-right of the hero tile */
-.hero-mute {
+/* Video controls, lower-right of the hero tile */
+.hero-controls {
   position: absolute;
   right: 12px;
   bottom: 12px;
   z-index: 3;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 8px;
+}
+.hero-control {
+  display: inline-flex;
+  align-items: center;
   background: oklch(15% 0.05 var(--hue) / 0.78);
   backdrop-filter: blur(8px);
   color: var(--hero-tint);
   border: 1px solid oklch(96% 0.02 var(--hue) / 0.18);
-  border-radius: 999px;
-  padding: 8px 14px 8px 10px;
   font-family: "Geist Mono", ui-monospace, monospace;
   font-size: 11px;
   letter-spacing: 0.06em;
@@ -273,18 +275,31 @@ button { font: inherit; cursor: pointer; }
   cursor: pointer;
   transition: transform 220ms var(--ease-out), background 220ms var(--ease-out);
 }
-.hero-mute:hover,
-.hero-mute:focus-visible {
+.hero-mute {
+  gap: 8px;
+  border-radius: 999px;
+  padding: 8px 14px 8px 10px;
+}
+.hero-playback {
+  width: 36px;
+  height: 36px;
+  flex: 0 0 36px;
+  justify-content: center;
+  border-radius: 50%;
+  padding: 0;
+}
+.hero-control:hover,
+.hero-control:focus-visible {
   background: oklch(20% 0.06 var(--hue) / 0.92);
   transform: translateY(-2px);
   outline: none;
 }
-.hero-mute:focus-visible { box-shadow: 0 0 0 3px var(--hero-tint); }
-.hero-mute svg { width: 16px; height: 16px; }
-.hero-mute .icon-play,
+.hero-control:focus-visible { box-shadow: 0 0 0 3px var(--hero-tint); }
+.hero-control svg { width: 16px; height: 16px; }
+.hero-playback .icon-play,
 .hero-mute .icon-sound { display: none; }
-.hero-mute[data-mode="play"] .icon-play { display: inline-block; }
-.hero-mute[data-mode="play"] .icon-muted { display: none; }
+.hero-playback[data-mode="play"] .icon-play { display: inline-block; }
+.hero-playback[data-mode="play"] .icon-pause { display: none; }
 .hero-mute[aria-pressed="false"] .icon-muted { display: none; }
 .hero-mute[aria-pressed="false"] .icon-sound { display: inline-block; }
 .hero-mute[aria-pressed="false"] .hero-mute-label::after { content: "sound on"; }


### PR DESCRIPTION
The hero video autoplays and loops with no way to pause it. This adds a small play/pause button beside the mute control and keeps its label and icon synced with the video state. I tested it on desktop, mobile, and with reduced motion enabled.